### PR TITLE
Update README API docs section to point to library docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,4 @@ This runs:
 
 ## API docs
 
-- GitHub Pages index: [johnynek.github.io/zafu](https://johnynek.github.io/zafu/)
-- Current module docs: [Zafu/Collection/Vector](https://johnynek.github.io/zafu/Zafu/Collection/Vector.html)
+- [Zafu library docs](https://johnynek.github.io/zafu/)


### PR DESCRIPTION
Replaced the two API docs bullets in README (`GitHub Pages index` and `Current module docs`) with a single link: `Zafu library docs` -> https://johnynek.github.io/zafu/. Kept scope limited to issue #14 with only a README change. Ran required validation command `scripts/test.sh` successfully (after fetching the local Bosatsu artifact with `./bosatsu --fetch`).

Fixes #14