### PR TITLE
Add Zafu/Control/Result with Rust-style Result API and adapters

### DIFF
--- a/src/Zafu/Control/Result.bosatsu
+++ b/src/Zafu/Control/Result.bosatsu
@@ -42,6 +42,7 @@ export (
   fold,
   unwrap_or,
   unwrap_or_else,
+  unwrap,
   from_Option,
   eq,
   ord,
@@ -53,18 +54,10 @@ enum Result[e, a]:
   Ok(ok: a)
 
 def is_err(result: Result[e, a]) -> Bool:
-  match result:
-    case Err(_):
-      True
-    case Ok(_):
-      False
+  result matches Err(_)
 
 def is_ok(result: Result[e, a]) -> Bool:
-  match result:
-    case Err(_):
-      False
-    case Ok(_):
-      True
+  result matches Ok(_)
 
 def err(result: Result[e, a]) -> Option[e]:
   match result:
@@ -134,6 +127,10 @@ def unwrap_or_else(result: Result[e, a], on_err: e -> a) -> a:
       on_err(err_value)
     case Ok(ok_value):
       ok_value
+
+def unwrap(ok: forall e. Result[e, a]) -> a:
+  Ok(value) = ok
+  value
 
 def from_Option(value: Option[a], on_none: () -> e) -> Result[e, a]:
   match value:
@@ -222,6 +219,7 @@ tests = TestSuite("Result tests", [
   Assertion(unwrap_or(Ok(2), 10).eq_Int(2), "unwrap_or Ok"),
   Assertion(unwrap_or_else(Err(1), _ -> 7).eq_Int(7), "unwrap_or_else Err"),
   Assertion(unwrap_or_else(Ok(2), _ -> 7).eq_Int(2), "unwrap_or_else Ok"),
+  Assertion(unwrap(Ok(3)).eq_Int(3), "unwrap polymorphic Ok"),
   Assertion(from_Option(Some(2), () -> 0) matches Ok(2), "from_Option Some"),
   Assertion(from_Option(None, () -> 0) matches Err(0), "from_Option None"),
   (


### PR DESCRIPTION
Implemented issue #42 by adding `src/Zafu/Control/Result.bosatsu` per the merged design doc. The new module defines `enum Result[e, a]: Err(err: e), Ok(ok: a)` and exports the full scoped API: predicates/views (`is_err`, `is_ok`, `err`, `ok`, `to_Option`), combinators (`map`, `map_err`, `and_then`, `flat_map`, `or_else`, `fold`), extraction/conversion helpers (`unwrap_or`, `unwrap_or_else`, `from_Option`), and typeclass adapters (`eq`, `ord`, `hash`). `ord` enforces `Err < Ok`, and `hash` uses constructor-specific seeds/tags with `mix_61`/`finish_61` so `Err(x)` and `Ok(x)` hash distinctly. Added an inline `tests` suite with branch-complete coverage for exported helpers plus adapter behavior/coherence checks (40 assertions total), including map identity/composition and short-circuit semantics. Validation completed successfully with `./bosatsu lib check`, `./bosatsu lib test`, and required `scripts/test.sh` (all passing).

Fixes #42

Implements design doc: [docs/design/42-design-zafu-control-result.md](https://github.com/johnynek/zafu/blob/main/docs/design/42-design-zafu-control-result.md)

Design source PR: https://github.com/johnynek/zafu/pull/44