### PR TITLE
Use Zafu/Collection/List.size to remove duplicated list length helpers

### DIFF
--- a/src/Zafu/Collection/Chain.bosatsu
+++ b/src/Zafu/Collection/Chain.bosatsu
@@ -24,6 +24,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop,
 )
+from Zafu/Collection/List import size as size_List
 
 export (
   Chain,
@@ -56,16 +57,6 @@ enum Chain[a: +*]:
   WrapList(items: List[a])
   Concat(left: Chain[a], right: Chain[a])
 
-def list_size_Chain_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_Chain_loop(tail, acc.add(1))
-
-def list_size_Chain(list: List[a]) -> Int:
-  list_size_Chain_loop(list, 0)
-
 def index_List_Chain_loop(list: List[a], idx: Int) -> Option[a]:
   loop list:
     case []:
@@ -90,7 +81,7 @@ def chain_size(chain: Chain[a]) -> Int:
     case WrapArray(items):
       size_Array(items)
     case WrapList(items):
-      list_size_Chain(items)
+      size_List(items)
     case Concat(left, right):
       chain_size(left).add(chain_size(right))
 
@@ -248,7 +239,7 @@ def find_with_Chain(chain: Chain[a], idx: Int, on_missing: () -> b, on_found: a 
               else:
                 loop_find(rem.sub(1), tail, rem_idx.sub(cnt))
             case [WrapList(items), *tail]:
-              cnt = list_size_Chain(items)
+              cnt = size_List(items)
               if cmp_Int(rem_idx, cnt) matches LT:
                 match index_List_Chain(items, rem_idx):
                   case Some(item):
@@ -319,16 +310,6 @@ def and_Bool(left: Bool, right: Bool) -> Bool:
     right
   else:
     False
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc.add(1))
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 def index_List_loop(list: List[a], idx: Int) -> Option[a]:
   loop list:
@@ -421,7 +402,7 @@ rand_list_int: Rand[List[Int]] = flat_map_Rand(
 )
 
 rand_list_with_index: Rand[(List[Int], Int)] = flat_map_Rand(rand_list_int, list -> (
-  upper = list_size(list).add(3)
+  upper = size_List(list).add(3)
   map_Rand(int_range(upper), i -> (list, i.sub(1)))
 ))
 
@@ -450,7 +431,7 @@ size_prop: Prop = forall_Prop(
   "size_Chain agrees with list_size",
   list -> (
     chain = from_List_Chain(list)
-    Assertion(size_Chain(chain).eq_Int(list_size(list)), "size law")
+    Assertion(size_Chain(chain).eq_Int(size_List(list)), "size law")
   ))
 
 singleton_prop: Prop = forall_Prop(
@@ -657,7 +638,7 @@ tests = TestSuite("Chain tests", [
     Assertion(and_Bool(
       and_Bool(
         size_Chain(deep).eq_Int(20000),
-        list_size(deep_list).eq_Int(20000)),
+        size_List(deep_list).eq_Int(20000)),
       and_Bool(
         foldl_Chain(deep, 0, add).eq_Int(expected_sum),
         foldr_Chain(deep, 0, (item, acc) -> item.add(acc)).eq_Int(expected_sum))),

--- a/src/Zafu/Collection/Deque.bosatsu
+++ b/src/Zafu/Collection/Deque.bosatsu
@@ -16,6 +16,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop,
 )
+from Zafu/Collection/List import size as size_List
 
 export (
   Queue,
@@ -42,16 +43,6 @@ enum Queue[a: +*]:
 
 # Canonical empty value.
 empty: forall a. Queue[a] = Queue(0, [], [])
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc.add(1))
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 def normalize(size: Int, front: List[a], back_rev: List[a]) -> Queue[a]:
   if cmp_Int(size, 0) matches LT | EQ:
@@ -81,7 +72,7 @@ def normalize_queue(queue: Queue[a]) -> Queue[a]:
 
 # Builds a deque from a list in iteration order.
 def from_List(list: List[a]) -> Queue[a]:
-  normalize(list_size(list), list, [])
+  normalize(size_List(list), list, [])
 
 # Returns items in iteration order.
 def to_List(queue: Queue[a]) -> List[a]:
@@ -311,7 +302,7 @@ size_prop: Prop = forall_Prop(
   "size agrees with list size",
   list -> (
     queue = from_List(list)
-    Assertion(size(queue).eq_Int(list_size(list)), "size law")
+    Assertion(size(queue).eq_Int(size_List(list)), "size law")
   ))
 
 is_empty_prop: Prop = forall_Prop(
@@ -319,7 +310,7 @@ is_empty_prop: Prop = forall_Prop(
   "is_empty agrees with list emptiness",
   list -> (
     queue = from_List(list)
-    expected = list_size(list).eq_Int(0)
+    expected = size_List(list).eq_Int(0)
     Assertion(eq_Bool(is_empty(queue), expected), "is_empty law")
   ))
 
@@ -468,7 +459,7 @@ tests = TestSuite("Deque tests", [
     deep_list = to_List(deep)
     Assertion(
       and_Bool(
-        and_Bool(size(deep).eq_Int(20000), list_size(deep_list).eq_Int(20000)),
+        and_Bool(size(deep).eq_Int(20000), size_List(deep_list).eq_Int(20000)),
         and_Bool(foldl(deep, 0, add).eq_Int(expected_sum), foldr(deep, 0, (item, acc) -> item.add(acc)).eq_Int(expected_sum))
       ),
       "deep stack-safe operations"

--- a/src/Zafu/Collection/HashMap.bosatsu
+++ b/src/Zafu/Collection/HashMap.bosatsu
@@ -27,6 +27,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop
 )
+from Zafu/Collection/List import size as size_List
 from Zafu/Abstract/Eq import (
   Eq,
   eq_from_fn,
@@ -130,16 +131,6 @@ def eq_Bool(left: Bool, right: Bool) -> Bool:
     right
   else:
     not_Bool(right)
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc + 1)
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 def popcount(value: Int) -> Int:
   def go(rem: Int, bits: Int, acc: Int) -> Int:
@@ -804,7 +795,7 @@ def model_contains(model: List[(Int, Int)], key: Int) -> Bool:
   model_get(model, key) matches Some(_)
 
 def model_eq(left: List[(Int, Int)], right: List[(Int, Int)]) -> Bool:
-  if list_size(left).eq_Int(list_size(right)):
+  if size_List(left).eq_Int(size_List(right)):
     eq_opt_int = eq_Option(eq_Int_inst)
     left.foldl_List(True, (ok, item) -> (
       if ok:
@@ -817,7 +808,7 @@ def model_eq(left: List[(Int, Int)], right: List[(Int, Int)]) -> Bool:
     False
 
 def map_matches_model(map: HashMap[Int, Int], model: List[(Int, Int)]) -> Bool:
-  if size(map).eq_Int(list_size(model)):
+  if size(map).eq_Int(size_List(model)):
     model.foldl_List(True, (ok, item) -> (
       if ok:
         (key, value) = item

--- a/src/Zafu/Collection/HashSet.bosatsu
+++ b/src/Zafu/Collection/HashSet.bosatsu
@@ -26,6 +26,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop
 )
+from Zafu/Collection/List import size as size_List
 from Zafu/Abstract/Eq import (
   Eq,
   eq_from_fn,
@@ -119,16 +120,6 @@ def eq_Bool(left: Bool, right: Bool) -> Bool:
     right
   else:
     not_Bool(right)
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc + 1)
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 def popcount(value: Int) -> Int:
   def go(rem: Int, bits: Int, acc: Int) -> Int:
@@ -690,7 +681,7 @@ def model_alter(model: List[Int], key: Int, present: Bool) -> List[Int]:
     model_remove(model, key)
 
 def model_eq(left: List[Int], right: List[Int]) -> Bool:
-  if list_size(left).eq_Int(list_size(right)):
+  if size_List(left).eq_Int(size_List(right)):
     left.foldl_List(True, (ok, key) -> (
       if ok:
         model_contains(right, key)
@@ -701,7 +692,7 @@ def model_eq(left: List[Int], right: List[Int]) -> Bool:
     False
 
 def set_matches_model(set: HashSet[Int], model: List[Int]) -> Bool:
-  if size(set).eq_Int(list_size(model)):
+  if size(set).eq_Int(size_List(model)):
     model.foldl_List(True, (ok, key) -> (
       if ok:
         contains(set, key)

--- a/src/Zafu/Collection/Heap.bosatsu
+++ b/src/Zafu/Collection/Heap.bosatsu
@@ -19,6 +19,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop,
 )
+from Zafu/Collection/List import size as size_List
 from Zafu/Abstract/Eq import (
   Eq,
   eq_from_fn,
@@ -84,16 +85,6 @@ def size(heap: Heap[a]) -> Int:
 # True if heap has no elements.
 def is_empty(heap: Heap[a]) -> Bool:
   size(heap).eq_Int(0)
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc.add(1))
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 # Returns the minimum element, if present.
 def min(heap: Heap[a]) -> Option[a]:
@@ -217,7 +208,7 @@ def merge_round(ord: Ord[a], trees: List[Tree[a]]) -> List[Tree[a]]:
 # Builds a heap with pairwise rounds to avoid one-sided insertion chains.
 def from_List(ord: Ord[a], items: List[a]) -> Heap[a]:
   trees0 = trees_from_list(items)
-  fuel = list_size(items).add(8)
+  fuel = size_List(items).add(8)
   trees_final = int_loop(fuel, trees0, (rem, trees) -> (
     match trees:
       case [] | [_]:
@@ -407,7 +398,7 @@ size_prop: Prop = forall_Prop(
   "size matches list size",
   list -> (
     heap = from_List(ord_Int, list)
-    Assertion(size(heap).eq_Int(list_size(list)), "size law")
+    Assertion(size(heap).eq_Int(size_List(list)), "size law")
   ))
 
 min_prop: Prop = forall_Prop(
@@ -462,7 +453,7 @@ combine_cross_order_prop: Prop = forall_Prop(
     asc = from_List(ord_Int, left)
     desc = from_List(reverse_Ord(ord_Int), right)
     combined = combine(asc, desc)
-    expected = if list_size(left).eq_Int(0):
+    expected = if size_List(left).eq_Int(0):
       sort_Int(right).reverse()
     else:
       sort_Int([*left, *right])

--- a/src/Zafu/Collection/LazyList.bosatsu
+++ b/src/Zafu/Collection/LazyList.bosatsu
@@ -21,6 +21,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop,
 )
+from Zafu/Collection/List import size as size_List
 
 export (
   LazyList,
@@ -83,17 +84,10 @@ def cons(head: Lazy[a], tail: LazyList[a]) -> LazyList[a]:
     LazyList(tail_size, _) = tail
     cons_take(head, lazy(() -> tail), tail_size.add(1))
 
-def len_List(list):
-    def go(list, acc):
-        loop list:
-            case [_, *tail]: go(tail, acc.add(1))
-            case []: acc
-    go(list, 0)
-
 # Builds a lazy list view over an existing strict list.
 # Construction is O(n) for length calculation, without rebuilding nodes.
 def from_List(lst: List[a]) -> LazyList[a]:
-  size = len_List(lst)
+  size = size_List(lst)
   if cmp_Int(size, 0) matches LT | EQ:
     empty_LazyList
   else:
@@ -412,16 +406,6 @@ def and_Bool(left: Bool, right: Bool) -> Bool:
   else:
     False
 
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc.add(1))
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
-
 def uncons_List(list: List[a]) -> Option[(a, List[a])]:
   match list:
     case []:
@@ -503,7 +487,7 @@ cons_prop: Prop = forall_Prop(
   prod_Rand(rand_int, rand_list_int),
   "cons_take then uncons returns the same head and tail",
   ((head, tail_list)) -> (
-    size = len_List(tail_list)
+    size = size_List(tail_list)
     ll = cons_take(lazy(() -> head), lazy(() -> from_List(tail_list)), size.add(1))
     match uncons(ll):
       case Some((actual_head, actual_tail)):
@@ -685,7 +669,7 @@ tests = TestSuite("LazyList tests", [
     deep_sum = foldl(deep, 0, add)
     Assertion(
       and_Bool(
-        list_size(deep_list).eq_Int(20000),
+        size_List(deep_list).eq_Int(20000),
         deep_sum.eq_Int(expected_sum)
       ),
       "deep concat stack-safe"

--- a/src/Zafu/Collection/Vector.bosatsu
+++ b/src/Zafu/Collection/Vector.bosatsu
@@ -35,6 +35,7 @@ from Bosatsu/Testing/Properties import (
   suite_Prop,
   run_Prop,
 )
+from Zafu/Collection/List import size as size_List
 
 export (
   Vector,
@@ -106,16 +107,6 @@ def max_Int(a: Int, b: Int) -> Int:
 
 def clamp_Int(value: Int, low: Int, high: Int) -> Int:
   min_Int(max_Int(value, low), high)
-
-def list_size_loop(list: List[a], acc: Int) -> Int:
-  loop list:
-    case []:
-      acc
-    case [_, *tail]:
-      list_size_loop(tail, acc.add(1))
-
-def list_size(list: List[a]) -> Int:
-  list_size_loop(list, 0)
 
 def chunk_count(total: Int) -> Int:
   if cmp_Int(total, 0) matches LT | EQ:
@@ -930,7 +921,7 @@ def take_list_model(list: List[Int], count: Int) -> List[Int]:
   slice_list_model(list, 0, count)
 
 def drop_list_model(list: List[Int], count: Int) -> List[Int]:
-  slice_list_model(list, count, list_size(list))
+  slice_list_model(list, count, size_List(list))
 
 def split_list_model(list: List[Int], count: Int) -> (List[Int], List[Int]):
   (take_list_model(list, count), drop_list_model(list, count))
@@ -947,19 +938,19 @@ rand_list_int: Rand[List[Int]] = flat_map_Rand(
 )
 
 rand_list_with_index: Rand[(List[Int], Int)] = flat_map_Rand(rand_list_int, list -> (
-  upper = list_size(list).add(3)
+  upper = size_List(list).add(3)
   map_Rand(int_range(upper), i -> (list, i.sub(1)))
 ))
 
 rand_list_with_index_item: Rand[(List[Int], Int, Int)] = flat_map_Rand(rand_list_int, list -> (
-  upper = list_size(list).add(4)
+  upper = size_List(list).add(4)
   map_Rand(prod_Rand(int_range(upper), rand_int), ((idx_0, item)) -> (
     (list, idx_0.sub(2), item)
   ))
 ))
 
 rand_list_with_slice_bounds: Rand[(List[Int], Int, Int)] = flat_map_Rand(rand_list_int, list -> (
-  upper = list_size(list).add(6)
+  upper = size_List(list).add(6)
   map_Rand(prod_Rand(int_range(upper), int_range(upper)), ((start_0, end_0)) -> (
     (list, start_0.sub(2), end_0.sub(2))
   ))
@@ -974,10 +965,10 @@ rand_deep_list_int: Rand[List[Int]] = flat_map_Rand(
 
 size_prop: Prop = forall_Prop(
   rand_list_int,
-  "size(from_List_Vector(list)) == list_size(list)",
+  "size(from_List_Vector(list)) == size_List(list)",
   list -> (
     vec = from_List_Vector(list)
-    Assertion(size(vec).eq_Int(list_size(list)), "size law")
+    Assertion(size(vec).eq_Int(size_List(list)), "size law")
   ))
 
 index_prop: Prop = forall_Prop(
@@ -1080,7 +1071,7 @@ concat_prop: Prop = forall_Prop(
     vec = concat_Vector(from_List_Vector(left), from_List_Vector(right))
     expected = left.concat(right)
     same_list = eq_List(eq_Int)(to_List_Vector(vec), expected)
-    same_size = size(vec).eq_Int(list_size(expected))
+    same_size = size(vec).eq_Int(size_List(expected))
     Assertion(and_Bool(same_list, same_size), "concat law")
   ))
 
@@ -1091,9 +1082,9 @@ concat_deep_iso_prop: Prop = forall_Prop(
     vec = concat_Vector(from_List_Vector(left), from_List_Vector(right))
     expected = left.concat(right)
     same_list = eq_List(eq_Int)(to_List_Vector(vec), expected)
-    same_size = size(vec).eq_Int(list_size(expected))
-    left_sz = list_size(left)
-    boundary_ok = if cmp_Int(left_sz, list_size(expected)) matches LT:
+    same_size = size(vec).eq_Int(size_List(expected))
+    left_sz = size_List(left)
+    boundary_ok = if cmp_Int(left_sz, size_List(expected)) matches LT:
       eq_Option(eq_Int)(index_Vector(vec, left_sz), index_List(expected, left_sz))
     else:
       True


### PR DESCRIPTION
Replaced duplicated list-length helpers in `Chain`, `Deque`, `HashMap`, `HashSet`, `Heap`, `LazyList`, and `Vector` with a single shared import of `Zafu/Collection/List.size` (aliased as `size_List`). Removed the local recursive length functions and updated all affected call sites (including property/test models) to use the centralized helper, with no behavior changes intended. Verified with the required command: `scripts/test.sh` (passes).

Fixes #53