### PR TITLE
Add Zafu/Collection/NonEmptyList with List-parity API and tests

### DIFF
--- a/src/Zafu/Collection/NonEmptyList.bosatsu
+++ b/src/Zafu/Collection/NonEmptyList.bosatsu
@@ -15,16 +15,34 @@ from Zafu/Collection/List import (
   zip as zip_List,
   filter as filter_List,
   flat_map as flat_map_List,
-  eq_List as eq_List_base,
 )
 
-from Zafu/Abstract/Hash import Hash
+from Zafu/Abstract/Eq import (
+  Eq,
+  eq_by,
+  eq as eq_Eq,
+)
+from Zafu/Abstract/Ord import (
+  Ord,
+  ord_by,
+  cmp as cmp_Ord,
+)
+from Zafu/Abstract/Hash import (
+  Hash,
+  hash_by,
+  hash as hash_Hash,
+)
 from Zafu/Collection/HashSet import (
   empty as empty_HashSet,
   contains as contains_HashSet,
   updated as updated_HashSet,
 )
 from Zafu/Abstract/Instances/Predef import (
+  eq_Int as eq_Int_inst,
+  ord_Int as ord_Int_inst,
+  eq_List as eq_List_inst,
+  ord_List as ord_List_inst,
+  hash_List as hash_List_inst,
   hash_Int,
 )
 
@@ -63,6 +81,8 @@ export (
   concat_all,
   reverse,
   eq_NonEmptyList,
+  ord_NonEmptyList,
+  hash_NonEmptyList,
 )
 
 struct NonEmptyList[a: +*](head: a, tail: List[a])
@@ -207,8 +227,14 @@ def distinct_by_hash(h: Hash[a], items: NonEmptyList[a]) -> NonEmptyList[a]:
   accepted = accepted_rev.foldl_List([], (acc, item) -> [item, *acc])
   from_non_empty_List_or(accepted, () -> singleton(head(items)))
 
-def eq_NonEmptyList(eq_item: (a, a) -> Bool, left: NonEmptyList[a], right: NonEmptyList[a]) -> Bool:
-  eq_List_base(eq_item, to_List(left), to_List(right))
+def eq_NonEmptyList(eq_item: Eq[a]) -> Eq[NonEmptyList[a]]:
+  eq_by(eq_List_inst(eq_item), to_List)
+
+def ord_NonEmptyList(ord_item: Ord[a]) -> Ord[NonEmptyList[a]]:
+  ord_by(ord_List_inst(ord_item), to_List)
+
+def hash_NonEmptyList(hash_item: Hash[a]) -> Hash[NonEmptyList[a]]:
+  hash_by(hash_List_inst(hash_item), to_List)
 
 tests = TestSuite("Zafu/Collection/NonEmptyList tests", [
   Assertion(
@@ -270,6 +296,38 @@ tests = TestSuite("Zafu/Collection/NonEmptyList tests", [
     "concat_all",
   ),
   Assertion(to_List(reverse(NonEmptyList(1, [2, 3]))) matches [3, 2, 1], "reverse"),
-  Assertion(eq_NonEmptyList(eq_Int, NonEmptyList(1, [2]), NonEmptyList(1, [2])), "eq_NonEmptyList equal"),
-  Assertion(eq_NonEmptyList(eq_Int, NonEmptyList(1, [2]), NonEmptyList(1, [3])) matches False, "eq_NonEmptyList mismatch"),
+  (
+    inst = eq_NonEmptyList(eq_Int_inst)
+    Assertion(eq_Eq(inst, NonEmptyList(1, [2]), NonEmptyList(1, [2])), "eq_NonEmptyList equal")
+  ),
+  (
+    inst = eq_NonEmptyList(eq_Int_inst)
+    Assertion(eq_Eq(inst, NonEmptyList(1, [2]), NonEmptyList(1, [3])) matches False, "eq_NonEmptyList mismatch")
+  ),
+  (
+    inst = ord_NonEmptyList(ord_Int_inst)
+    Assertion(cmp_Ord(inst, NonEmptyList(1, [2]), NonEmptyList(1, [3])) matches LT, "ord_NonEmptyList payload")
+  ),
+  (
+    inst = ord_NonEmptyList(ord_Int_inst)
+    Assertion(cmp_Ord(inst, NonEmptyList(1, [2]), NonEmptyList(1, [2])) matches EQ, "ord_NonEmptyList equal")
+  ),
+  (
+    hash_inst = hash_NonEmptyList(hash_Int)
+    hx = hash_Hash(hash_inst, NonEmptyList(1, [2, 3]))
+    hy = hash_Hash(hash_inst, NonEmptyList(1, [2, 3]))
+    Assertion(eq_Int(hx, hy), "hash_NonEmptyList equal values")
+  ),
+  (
+    hash_inst = hash_NonEmptyList(hash_Int)
+    hx = hash_Hash(hash_inst, NonEmptyList(1, [2, 3]))
+    hy = hash_Hash(hash_inst, NonEmptyList(1, [2, 4]))
+    Assertion(
+      if eq_Int(hx, hy):
+        False
+      else:
+        True,
+      "hash_NonEmptyList differs for sample unequal values",
+    )
+  ),
 ])


### PR DESCRIPTION
Implemented issue #57 in `src/Zafu/Collection/NonEmptyList.bosatsu` following the merged design doc. Added `struct NonEmptyList[a: +*](head: a, tail: List[a])`, exported constructor `NonEmptyList()`, and implemented the full API inventory from the design: constructors/conversions (`singleton`, `from_prepend`, `from_append`, `from_List`, `to_List`), shape/query helpers (`head`, `tail`, `uncons`, `last`, `size`, `is_empty`, `any`, `exists`, `for_all`, `get`, `get_or`, `set`), folds/transforms (`foldl`, `foldr`, `sum`, `sumf`, `map`, `flat_map`, `sort`, `zip`, `filter`, `distinct_by_hash`), structural ops (`prepend`, `append`, `concat`, `concat_all`, `reverse`), and equality helper (`eq_NonEmptyList`).

List-parity behavior is delegated through `Zafu/Collection/List` where appropriate, and non-empty reconstruction is centralized via a private helper with explicit defensive fallback branches to preserve invariants.

Added comprehensive module tests (51 assertions) covering constructor/pattern-matching, conversion laws, all exported functions, and required edge behaviors: `from_List([]) == None`, `filter` all-false returns `None`, `set` negative/out-of-range semantics, singleton `zip`, non-empty preservation for `map`/`sort`, and stable first-seen output for `distinct_by_hash`.

Validation completed successfully:
- `./bosatsu lib check`
- `./bosatsu lib test`
- `scripts/test.sh`

Fixes #57

Implements design doc: [docs/design/57-add-zafu-collection-nonemptylist.md](https://github.com/johnynek/zafu/blob/main/docs/design/57-add-zafu-collection-nonemptylist.md)

Design source PR: https://github.com/johnynek/zafu/pull/58