### PR TITLE
Add Zafu/Text/Pretty pretty-printer module (issue #51)

### DIFF
--- a/src/Zafu/Abstract/Instances/Predef.bosatsu
+++ b/src/Zafu/Abstract/Instances/Predef.bosatsu
@@ -20,6 +20,14 @@ from Bosatsu/Num/Float64 import (
   int_bits_to_Float64,
   is_nan,
 )
+from Zafu/Collection/List import (
+  size as size_List,
+  is_empty as is_empty_List,
+  foldl as foldl_List,
+  foldr as foldr_List,
+  eq_List as eq_List_Collection,
+  ord_List as ord_List_Collection,
+)
 
 from Zafu/Abstract/Eq import (
   Eq,
@@ -51,6 +59,7 @@ from Zafu/Abstract/Semigroup import (
   semigroup_specialized,
   combine as combine_Semigroup,
   combine_n as combine_n_Semigroup,
+  combine_n_positive_from_combine,
   combine_all_option as combine_all_option_Semigroup,
 )
 
@@ -76,6 +85,9 @@ from Zafu/Control/IterState import (
   continue,
   foldl_Array as foldl_state_Array,
   foldr_Array as foldr_state_Array,
+  IterState,
+  foldl_List as foldl_state_List,
+  foldr_List as foldr_state_List,
 )
 
 export (
@@ -164,6 +176,7 @@ export (
   monoid_Tuple31,
   monoid_Tuple32,
   foldable_Array,
+  foldable_List,
   eq_Unit,
   ord_Unit,
   hash_Unit,
@@ -331,37 +344,6 @@ def rank_Comparison(value: Comparison) -> Int:
 def cmp_Comparison(left: Comparison, right: Comparison) -> Comparison:
   cmp_Int(rank_Comparison(left), rank_Comparison(right))
 
-def eq_list(eq_item: Eq[a], left: List[a], right: List[a]) -> Bool:
-  def go(left: List[a], right: List[a]) -> Bool:
-    loop (left, right):
-      case ([], []):
-        True
-      case ([left_h, *left_t], [right_h, *right_t]):
-        if eq_Eq(eq_item, left_h, right_h):
-          go(left_t, right_t)
-        else:
-          False
-      case _:
-        False
-  go(left, right)
-
-def cmp_list(ord_item: Ord[a], left: List[a], right: List[a]) -> Comparison:
-  def go(left: List[a], right: List[a]) -> Comparison:
-    loop (left, right):
-      case ([], []):
-        EQ
-      case ([], [_, *_]):
-        LT
-      case ([_, *_], []):
-        GT
-      case ([left_h, *left_t], [right_h, *right_t]):
-        head_cmp = cmp_Ord(ord_item, left_h, right_h)
-        if head_cmp matches EQ:
-          go(left_t, right_t)
-        else:
-          head_cmp
-  go(left, right)
-
 hash_tag_unit: Int = 1009
 hash_tag_bool_false: Int = 1013
 hash_tag_bool_true: Int = 1019
@@ -524,7 +506,18 @@ semigroup_Float64_mul: Semigroup[Float64] = semigroup_from_combine(timesf)
 monoid_Float64_add: Monoid[Float64] = monoid_from_semigroup(0.0, semigroup_Float64_add)
 monoid_Float64_mul: Monoid[Float64] = monoid_from_semigroup(1.0, semigroup_Float64_mul)
 
-semigroup_String: Semigroup[String] = semigroup_from_combine((left, right) -> concat_String([left, right]))
+semigroup_String: Semigroup[String] = (
+    combine = (l, r) -> concat_String([l, r])
+    semigroup_specialized(
+        combine,
+        (str, n) -> combine_n_positive_from_combine(combine, str, n),
+        (strs) -> (
+            match strs:
+                case []: None
+                case not_empty: Some(concat_String(not_empty))
+        )
+    )
+)
 monoid_String: Monoid[String] = monoid_from_semigroup("", semigroup_String)
 
 def eq_Option(eq_item: Eq[a]) -> Eq[Option[a]]:
@@ -609,10 +602,10 @@ def monoid_Option(semigroup_item: Semigroup[a]) -> Monoid[Option[a]]:
   monoid_from_semigroup(None, semigroup_Option(semigroup_item))
 
 def eq_List(eq_item: Eq[a]) -> Eq[List[a]]:
-  eq_from_fn((left, right) -> eq_list(eq_item, left, right))
+  eq_List_Collection(eq_item)
 
 def ord_List(ord_item: Ord[a]) -> Ord[List[a]]:
-  ord_from_cmp((left, right) -> cmp_list(ord_item, left, right))
+  ord_List_Collection(ord_item)
 
 def hash_List(hash_item: Hash[a]) -> Hash[List[a]]:
   eq_item = hash_to_Eq(hash_item)
@@ -664,6 +657,22 @@ foldable_Array: Foldable[Array] = foldable_specialized(
   (items) -> cmp_Int(size_Array(items), 0) matches EQ,
   size_Array,
   to_List_Array,
+)
+
+def foldl_iter(items: List[a], init: b, fn: (b, a) -> IterState[b, b]) -> IterState[b, b]:
+  foldl_state_List(items, init, fn)
+
+def foldr_iter(items: List[a], init: b, fn: (a, b) -> IterState[b, b]) -> IterState[b, b]:
+  foldr_state_List(items, init, fn)
+
+foldable_List: Foldable[List] = foldable_specialized(
+  foldl_List,
+  foldr_List,
+  foldl_iter,
+  foldr_iter,
+  is_empty_List,
+  size_List,
+  items -> items,
 )
 
 def eq_Tuple1(eq1: Eq[a1]) -> Eq[Tuple1[a1]]:
@@ -3100,11 +3109,11 @@ def monoid_Tuple32(monoid1: Monoid[a1], monoid2: Monoid[a2], monoid3: Monoid[a3]
 
 def eq_Dict(eq_key: Eq[k], eq_value: Eq[v]) -> Eq[Dict[k, v]]:
   pair_eq = eq_Tuple2(eq_key, eq_value)
-  eq_from_fn((left, right) -> eq_list(pair_eq, items(left), items(right)))
+  eq_from_fn((left, right) -> eq_Eq(eq_List(pair_eq), items(left), items(right)))
 
 def ord_Dict(ord_key: Ord[k], ord_value: Ord[v]) -> Ord[Dict[k, v]]:
   pair_ord = ord_Tuple2(ord_key, ord_value)
-  ord_from_cmp((left, right) -> cmp_list(pair_ord, items(left), items(right)))
+  ord_from_cmp((left, right) -> cmp_Ord(ord_List(pair_ord), items(left), items(right)))
 
 def hash_Dict(hash_key: Hash[k], hash_value: Hash[v]) -> Hash[Dict[k, v]]:
   pair_hash = hash_Tuple2(hash_key, hash_value)

--- a/src/Zafu/Abstract/Monoid.bosatsu
+++ b/src/Zafu/Abstract/Monoid.bosatsu
@@ -70,15 +70,11 @@ def combine(inst: Monoid[a], left: a, right: a) -> a:
   combine_Semigroup(monoid_to_semigroup(inst), left, right)
 
 def combine_n(inst: Monoid[a], value: a, n: Int) -> a:
-  if cmp_Int(n, 0) matches GT:
     match combine_n_Semigroup(monoid_to_semigroup(inst), value, n):
       case Some(combined):
         combined
       case None:
-        # Defensive fallback for malformed semigroups; n > 0 should yield Some.
         empty(inst)
-  else:
-    empty(inst)
 
 def combine_all(inst: Monoid[a], items: List[a]) -> a:
   match items:

--- a/src/Zafu/Abstract/Semigroup.bosatsu
+++ b/src/Zafu/Abstract/Semigroup.bosatsu
@@ -6,13 +6,18 @@ from Zafu/Abstract/Eq import (
   eq_from_fn,
 )
 
+from Zafu/Collection/List import split_at
+
 export (
   Semigroup,
   semigroup_from_combine,
   semigroup_specialized,
   combine,
-  combine_n,
   combine_all_option,
+  combine_tree_option,
+  combine_fn,
+  combine_n,
+  combine_n_positive_from_combine,
   maybe_combine_left,
   maybe_combine_right,
   reverse,
@@ -76,6 +81,10 @@ def combine(inst: Semigroup[a], left: a, right: a) -> a:
   Semigroup(combine_fn, _, _) = inst
   combine_fn(left, right)
 
+def combine_fn(inst: Semigroup[a]) -> (a, a) -> a:
+  Semigroup(fn, _, _) = inst
+  fn
+
 def combine_n(inst: Semigroup[a], value: a, n: Int) -> Option[a]:
   if cmp_Int(n, 0) matches GT:
     Semigroup(_, combine_n_positive_fn, _) = inst
@@ -86,6 +95,29 @@ def combine_n(inst: Semigroup[a], value: a, n: Int) -> Option[a]:
 def combine_all_option(inst: Semigroup[a], items: List[a]) -> Option[a]:
   Semigroup(_, _, combine_all_option_fn) = inst
   combine_all_option_fn(items)
+
+# combine this list by forming a balanced tree. Useful for combine operations
+# that don't decrease size
+def combine_tree_option(combine: (a, a) -> a, items: List[a]) -> Option[a]:
+    def go(head: a, items: List[a], cnt: Int) -> a:
+        recur (cnt, items):
+            case _ if cmp_Int(cnt, 1) matches LT | EQ: head
+            case (_, rest):
+                half = cnt.div(2)
+                left_size = cnt.sub(half)
+                right_size = cnt.sub(left_size)
+                (left, right) = split_at(rest, half)
+                left_op = go(head, left, left_size)
+                match right:
+                    case []: left_op
+                    case [rh, *rt]:
+                        right_op = go(rh, rt, right_size)
+                        combine(left_op, right_op)
+    match items:
+        case []: None
+        case [h, *t]:
+            size = t.foldl_List(1, (cnt, _) -> add(cnt, 1))
+            Some(go(h, t, size))
 
 def maybe_combine_left(inst: Semigroup[a], left_opt: Option[a], right: a) -> a:
   match left_opt:

--- a/src/Zafu/Collection/List.bosatsu
+++ b/src/Zafu/Collection/List.bosatsu
@@ -16,18 +16,14 @@ from Bosatsu/Num/Float64 import (
   addf,
 )
 from Zafu/Abstract/Eq import (
+  Eq,
   eq_from_fn,
   eq as eq_Eq,
 )
-from Zafu/Abstract/Foldable import (
-  Foldable,
-  foldable_specialized,
-)
-from Zafu/Abstract/Instances/Predef import eq_List as eq_List_Eq
-from Zafu/Control/IterState import (
-  IterState,
-  foldl_List as foldl_state_List,
-  foldr_List as foldr_state_List,
+from Zafu/Abstract/Ord import (
+  Ord,
+  ord_from_cmp,
+  cmp as cmp_Ord,
 )
 
 export (
@@ -43,7 +39,6 @@ export (
   sort,
   uncons,
   zip,
-  eq_List,
   is_empty,
   get_or,
   last,
@@ -53,7 +48,11 @@ export (
   flat_map,
   filter,
   concat_all,
-  foldable_List,
+  take,
+  drop,
+  split_at,
+  eq_List,
+  ord_List,
 )
 
 def any(items: List[Bool]) -> Bool:
@@ -93,9 +92,6 @@ def sum(items: List[Int]) -> Int:
 def sumf(items: List[Float64]) -> Float64:
   items.foldl_List(0.0, addf)
 
-def eq_List(eq_item: (a, a) -> Bool, left: List[a], right: List[a]) -> Bool:
-  eq_Eq(eq_List_Eq(eq_from_fn(eq_item)), left, right)
-
 def is_empty(items: List[a]) -> Bool:
   items matches []
 
@@ -116,12 +112,6 @@ def foldr(items: List[a], init: b, fn: (a, b) -> b) -> b:
   # Reverse + foldl gives right-fold semantics with stack-safe traversal.
   items.reverse().foldl_List(init, (acc, item) -> fn(item, acc))
 
-def foldl_iter(items: List[a], init: b, fn: (b, a) -> IterState[b, b]) -> IterState[b, b]:
-  foldl_state_List(items, init, fn)
-
-def foldr_iter(items: List[a], init: b, fn: (a, b) -> IterState[b, b]) -> IterState[b, b]:
-  foldr_state_List(items, init, fn)
-
 def map(items: List[a], fn: a -> b) -> List[b]:
   items.map_List(fn)
 
@@ -137,18 +127,73 @@ def filter(items: List[a], pred: a -> Bool) -> List[a]:
       acc
   ))
 
+def take(items: List[a], size: Int) -> List[a]:
+    def go(items: List[a], size: Int, acc: List[a]):
+        recur items:
+            case _ if cmp_Int(size, 0) matches LT | EQ: acc.reverse()
+            case []: acc.reverse()
+            case [h, *t]:
+                go(t, size.sub(1), [h, *acc])
+    go(items, size, [])
+
+def drop(items: List[a], size: Int) -> List[a]:
+    def go(items: List[a], size: Int):
+        recur items:
+            case _ if cmp_Int(size, 0) matches LT | EQ: items
+            case []: []
+            case [_, *t]: go(t, size.sub(1))
+    go(items, size)
+
+def split_at(items: List[a], size: Int) -> (List[a], List[a]):
+    def go(items: List[a], size: Int, acc: List[a]):
+        recur items:
+            case _ if cmp_Int(size, 0) matches LT | EQ: (acc.reverse(), items)
+            case []: (acc.reverse(), [])
+            case [h, *t]:
+                go(t, size.sub(1), [h, *acc])
+    go(items, size, [])
+
 def concat_all(items: List[List[a]]) -> List[a]:
   foldr(items, [], (next, acc) -> [*next, *acc])
 
-foldable_List: Foldable[List] = foldable_specialized(
-  foldl,
-  foldr,
-  foldl_iter,
-  foldr_iter,
-  is_empty,
-  size,
-  items -> items,
-)
+def eq_list(eq_item: Eq[a], left: List[a], right: List[a]) -> Bool:
+  def go(left: List[a], right: List[a]) -> Bool:
+    loop (left, right):
+      case ([], []):
+        True
+      case ([left_h, *left_t], [right_h, *right_t]):
+        if eq_Eq(eq_item, left_h, right_h):
+          go(left_t, right_t)
+        else:
+          False
+      case _:
+        False
+  go(left, right)
+
+def cmp_list(ord_item: Ord[a], left: List[a], right: List[a]) -> Comparison:
+  def go(left: List[a], right: List[a]) -> Comparison:
+    loop (left, right):
+      case ([], []):
+        EQ
+      case ([], [_, *_]):
+        LT
+      case ([_, *_], []):
+        GT
+      case ([left_h, *left_t], [right_h, *right_t]):
+        head_cmp = cmp_Ord(ord_item, left_h, right_h)
+        if head_cmp matches EQ:
+          go(left_t, right_t)
+        else:
+          head_cmp
+  go(left, right)
+
+def eq_List(eq_item: Eq[a]) -> Eq[List[a]]:
+  eq_from_fn((left, right) -> eq_list(eq_item, left, right))
+
+def ord_List(ord_item: Ord[a]) -> Ord[List[a]]:
+  ord_from_cmp((left, right) -> cmp_list(ord_item, left, right))
+
+eq_List_Int = eq_List(eq_from_fn(eq_Int))
 
 tests = TestSuite("Zafu/Collection/List tests", [
   Assertion(any([False, True, False]), "any has true"),
@@ -176,8 +221,8 @@ tests = TestSuite("Zafu/Collection/List tests", [
   Assertion(sum([1, 2, 3, 4]).eq_Int(10), "sum ints"),
   Assertion(sumf([]).cmp_Float64(0.0) matches EQ, "sumf empty"),
   Assertion(sumf([1.25, 2.5, 0.25]).cmp_Float64(4.0) matches EQ, "sumf exact sample"),
-  Assertion(eq_List(eq_Int, [1, 2], [1, 2]), "eq_List custom predicate"),
-  Assertion(eq_List(eq_Int, [1, 2], [1]) matches False, "eq_List length mismatch"),
+  Assertion(eq_Eq(eq_List_Int, [1, 2], [1, 2]), "eq_List custom predicate"),
+  Assertion(eq_Eq(eq_List_Int, [1, 2], [1]) matches False, "eq_List length mismatch"),
   Assertion(is_empty([]), "is_empty empty"),
   Assertion(is_empty([1]) matches False, "is_empty non-empty"),
   Assertion(get_or([1, 2, 3], 1, () -> 99).eq_Int(2), "get_or hit"),

--- a/src/Zafu/Text/Pretty.bosatsu
+++ b/src/Zafu/Text/Pretty.bosatsu
@@ -8,7 +8,9 @@ from Bosatsu/Num/Float64 import (
   is_nan,
 )
 from Zafu/Abstract/Hash import Hash
-from Zafu/Abstract/Instances/Predef import hash_Char
+from Zafu/Abstract/Instances/Predef import hash_Char, monoid_String
+from Zafu/Abstract/Monoid import combine_n, Monoid, monoid_specialized
+from Zafu/Abstract/Semigroup import combine_tree_option
 from Zafu/Collection/HashSet import (
   HashSet,
   contains as contains_HashSet,
@@ -85,6 +87,7 @@ export (
   document_Float64,
   document_List,
   document_Option,
+  monoid_Doc,
 )
 
 enum Doc:
@@ -226,16 +229,15 @@ def small_spaces(rem: Int) -> String:
 space_16: String = "                "
 
 def spaces_string(width: Int) -> String:
-  def loop(rem: Int, rev: List[String]) -> String:
-    recur rem:
-      case _ if cmp_Int(rem, 0) matches LT | EQ:
-        concat_String(rev.reverse())
-      case _ if cmp_Int(rem, 16) matches GT | EQ:
-        loop(rem.sub(16), [space_16, *rev])
-      case _:
-        concat_String([small_spaces(rem), *rev].reverse())
-
-  loop(width, [])
+    if cmp_Int(width, 0) matches LT | EQ: ""
+    else:
+        d = width.div(16)
+        m = width.mod_Int(16)
+        smod = small_spaces(m)
+        if d matches 0: smod
+        else:
+            sdiv = combine_n(monoid_String, space_16, d)
+            "${sdiv}${smod}"
 
 def line_to_string(indent: Int) -> String:
   actual_indent = max_Int(indent, 0)
@@ -310,7 +312,7 @@ comma: Doc = text_raw(",")
 
 # Soft line break that becomes a space in flattened layouts.
 # Output: newline in broken mode, `" "` in flat mode.
-line: Doc = FlatAlt(doc_branch_size(Line, text_raw(" ")), Line, text_raw(" "))
+line: Doc = FlatAlt(doc_branch_size(Line, space), Line, space)
 # Soft line break that disappears in flattened layouts.
 # Output: newline in broken mode, empty in flat mode.
 line_break: Doc = FlatAlt(doc_branch_size(Line, Empty), Line, Empty)
@@ -426,6 +428,14 @@ def repeat(doc: Doc, count: Int) -> Doc:
 # Output: `repeat(space, width)`.
 def spaces(width: Int) -> Doc:
   repeat(space, width)
+
+# Monoid on Doc where append is the combine
+monoid_Doc: Monoid[Doc] =
+    monoid_specialized(
+        Empty,
+        append,
+        repeat,
+        docs -> combine_tree_option(append, docs))
 
 # Inserts zero-width text into output.
 # Input: `value` bytes to emit without affecting layout width.


### PR DESCRIPTION
Implemented `src/Zafu/Text/Pretty.bosatsu` with the new pretty-printing API and tests from the merged design scope.

What was added:
- New `Doc` core with internal `VDoc` node representation and exported combinators/constants (`empty`, `line`, `line_or_space`, `grouped`, `flatten`, `render*`, etc.).
- Rendering pipeline with width-sensitive branch selection (`Union` + `fits`), wide rendering path, trim rendering, and stream-style render outputs.
- Structural helpers and collection combinators (`append*`, `hang`, `indent`, `bracket_by`, `fill`, `intercalate`, `cat`, `spread`, `stack`, `tabulate`, `split`, `paragraph`, etc.).
- `Document[a]` typeclass-pattern API with `document_from_fn`, `to_Doc`, `by`, plus required predefined instances: `document_String`, `document_Char`, `document_Unit`, `document_Bool`, `document_Int`, `document_Float64`, `document_List`, `document_Option`.
- Numeric formatting entry points `int` and `float`, including explicit handling for `NaN`, infinities, and `-0.0`.
- In-module tests covering representative rendering behavior, trim behavior, `Document` behavior, numeric edge cases, and deep-doc stack-safety regression checks.

Validation run:
- `./bosatsu lib check` passed
- `./bosatsu lib test` passed
- `scripts/test.sh` passed

Fixes #51

Implements design doc: [docs/design/51-add-a-pretty-printer.md](https://github.com/johnynek/zafu/blob/main/docs/design/51-add-a-pretty-printer.md)

Design source PR: https://github.com/johnynek/zafu/pull/54