### PR TITLE
Add Semigroup abstraction and Predef semigroup instances

### DIFF
--- a/src/Zafu/Abstract/Instances/Predef.bosatsu
+++ b/src/Zafu/Abstract/Instances/Predef.bosatsu
@@ -40,7 +40,10 @@ from Zafu/Abstract/Hash import (
 from Zafu/Abstract/Semigroup import (
   Semigroup,
   semigroup_from_combine,
+  semigroup_specialized,
   combine as combine_Semigroup,
+  combine_n as combine_n_Semigroup,
+  combine_all_option as combine_all_option_Semigroup,
 )
 
 export (
@@ -371,8 +374,56 @@ hash_String: Hash[String] = hash_specialized(hash_string_value, eq_String)
 
 semigroup_Unit: Semigroup[Unit] = semigroup_from_combine((left, _) -> left)
 
-semigroup_Bool_and: Semigroup[Bool] = semigroup_from_combine(and_Bool)
-semigroup_Bool_or: Semigroup[Bool] = semigroup_from_combine(or_Bool)
+def combine_n_positive_or_self(semigroup_item: Semigroup[a], value: a, n: Int) -> a:
+  match combine_n_Semigroup(semigroup_item, value, n):
+    case Some(combined):
+      combined
+    case None:
+      value
+
+def combine_all_option_Bool_and(items: List[Bool]) -> Option[Bool]:
+  def go(rem: List[Bool]) -> Option[Bool]:
+    loop rem:
+      case []:
+        Some(True)
+      case [head, *tail]:
+        if head:
+          go(tail)
+        else:
+          Some(False)
+  match items:
+    case []:
+      None
+    case _:
+      go(items)
+
+def combine_all_option_Bool_or(items: List[Bool]) -> Option[Bool]:
+  def go(rem: List[Bool]) -> Option[Bool]:
+    loop rem:
+      case []:
+        Some(False)
+      case [head, *tail]:
+        if head:
+          Some(True)
+        else:
+          go(tail)
+  match items:
+    case []:
+      None
+    case _:
+      go(items)
+
+semigroup_Bool_and: Semigroup[Bool] = semigroup_specialized(
+  and_Bool,
+  (value, _) -> value,
+  combine_all_option_Bool_and,
+)
+
+semigroup_Bool_or: Semigroup[Bool] = semigroup_specialized(
+  or_Bool,
+  (value, _) -> value,
+  combine_all_option_Bool_or,
+)
 
 semigroup_Int_add: Semigroup[Int] = semigroup_from_combine((left, right) -> left.add(right))
 semigroup_Int_mul: Semigroup[Int] = semigroup_from_combine((left, right) -> left.mul(right))
@@ -417,17 +468,48 @@ def hash_Option(hash_item: Hash[a]) -> Hash[Option[a]]:
   ), eq_Option(eq_item))
 
 def semigroup_Option(semigroup_item: Semigroup[a]) -> Semigroup[Option[a]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Some(left_v), Some(right_v)):
-        Some(combine_Semigroup(semigroup_item, left_v, right_v))
-      case (Some(_), None):
-        left
-      case (None, Some(_)):
-        right
-      case (None, None):
-        None
-  ))
+  semigroup_specialized(
+    (left, right) -> (
+      match (left, right):
+        case (Some(left_v), Some(right_v)):
+          Some(combine_Semigroup(semigroup_item, left_v, right_v))
+        case (Some(_), None):
+          left
+        case (None, Some(_)):
+          right
+        case (None, None):
+          None
+    ),
+    (value, n) -> (
+      match value:
+        case None:
+          None
+        case Some(item):
+          match combine_n_Semigroup(semigroup_item, item, n):
+            case Some(combined):
+              Some(combined)
+            case None:
+              None
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case _:
+          present_rev = items.foldl_List([], (acc, next) -> (
+            match next:
+              case None:
+                acc
+              case Some(item):
+                [item, *acc]
+          ))
+          match combine_all_option_Semigroup(semigroup_item, present_rev.reverse()):
+            case Some(combined):
+              Some(Some(combined))
+            case None:
+              Some(None)
+    ),
+  )
 
 def eq_List(eq_item: Eq[a]) -> Eq[List[a]]:
   eq_from_fn((left, right) -> eq_list(eq_item, left, right))
@@ -2109,228 +2191,580 @@ def hash_Tuple32(hash1: Hash[a1], hash2: Hash[a2], hash3: Hash[a3], hash4: Hash[
   )), eq_Tuple32(eq1, eq2, eq3, eq4, eq5, eq6, eq7, eq8, eq9, eq10, eq11, eq12, eq13, eq14, eq15, eq16, eq17, eq18, eq19, eq20, eq21, eq22, eq23, eq24, eq25, eq26, eq27, eq28, eq29, eq30, eq31, eq32))
 
 def semigroup_Tuple1(semigroup1: Semigroup[a1]) -> Semigroup[Tuple1[a1]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple1(left1), Tuple1(right1)):
-        Tuple1(combine_Semigroup(semigroup1, left1, right1))
-  ))
+  combine_fn = ((Tuple1(left1)), (Tuple1(right1))) -> (
+    Tuple1(combine_Semigroup(semigroup1, left1, right1))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple1(value1)), n) -> (
+      Tuple1(combine_n_positive_or_self(semigroup1, value1, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple2(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2]) -> Semigroup[Tuple2[a1, a2]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple2(left1, left2), Tuple2(right1, right2)):
-        Tuple2(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2))
-  ))
+  combine_fn = ((Tuple2(left1, left2)), (Tuple2(right1, right2))) -> (
+    Tuple2(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple2(value1, value2)), n) -> (
+      Tuple2(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple3(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3]) -> Semigroup[Tuple3[a1, a2, a3]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple3(left1, left2, left3), Tuple3(right1, right2, right3)):
-        Tuple3(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3))
-  ))
+  combine_fn = ((Tuple3(left1, left2, left3)), (Tuple3(right1, right2, right3))) -> (
+    Tuple3(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple3(value1, value2, value3)), n) -> (
+      Tuple3(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple4(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4]) -> Semigroup[Tuple4[a1, a2, a3, a4]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple4(left1, left2, left3, left4), Tuple4(right1, right2, right3, right4)):
-        Tuple4(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4))
-  ))
+  combine_fn = ((Tuple4(left1, left2, left3, left4)), (Tuple4(right1, right2, right3, right4))) -> (
+    Tuple4(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple4(value1, value2, value3, value4)), n) -> (
+      Tuple4(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple5(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5]) -> Semigroup[Tuple5[a1, a2, a3, a4, a5]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple5(left1, left2, left3, left4, left5), Tuple5(right1, right2, right3, right4, right5)):
-        Tuple5(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5))
-  ))
+  combine_fn = ((Tuple5(left1, left2, left3, left4, left5)), (Tuple5(right1, right2, right3, right4, right5))) -> (
+    Tuple5(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple5(value1, value2, value3, value4, value5)), n) -> (
+      Tuple5(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple6(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6]) -> Semigroup[Tuple6[a1, a2, a3, a4, a5, a6]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple6(left1, left2, left3, left4, left5, left6), Tuple6(right1, right2, right3, right4, right5, right6)):
-        Tuple6(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6))
-  ))
+  combine_fn = ((Tuple6(left1, left2, left3, left4, left5, left6)), (Tuple6(right1, right2, right3, right4, right5, right6))) -> (
+    Tuple6(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple6(value1, value2, value3, value4, value5, value6)), n) -> (
+      Tuple6(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple7(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7]) -> Semigroup[Tuple7[a1, a2, a3, a4, a5, a6, a7]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple7(left1, left2, left3, left4, left5, left6, left7), Tuple7(right1, right2, right3, right4, right5, right6, right7)):
-        Tuple7(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7))
-  ))
+  combine_fn = ((Tuple7(left1, left2, left3, left4, left5, left6, left7)), (Tuple7(right1, right2, right3, right4, right5, right6, right7))) -> (
+    Tuple7(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple7(value1, value2, value3, value4, value5, value6, value7)), n) -> (
+      Tuple7(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple8(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8]) -> Semigroup[Tuple8[a1, a2, a3, a4, a5, a6, a7, a8]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple8(left1, left2, left3, left4, left5, left6, left7, left8), Tuple8(right1, right2, right3, right4, right5, right6, right7, right8)):
-        Tuple8(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8))
-  ))
+  combine_fn = ((Tuple8(left1, left2, left3, left4, left5, left6, left7, left8)), (Tuple8(right1, right2, right3, right4, right5, right6, right7, right8))) -> (
+    Tuple8(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple8(value1, value2, value3, value4, value5, value6, value7, value8)), n) -> (
+      Tuple8(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple9(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9]) -> Semigroup[Tuple9[a1, a2, a3, a4, a5, a6, a7, a8, a9]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple9(left1, left2, left3, left4, left5, left6, left7, left8, left9), Tuple9(right1, right2, right3, right4, right5, right6, right7, right8, right9)):
-        Tuple9(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9))
-  ))
+  combine_fn = ((Tuple9(left1, left2, left3, left4, left5, left6, left7, left8, left9)), (Tuple9(right1, right2, right3, right4, right5, right6, right7, right8, right9))) -> (
+    Tuple9(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple9(value1, value2, value3, value4, value5, value6, value7, value8, value9)), n) -> (
+      Tuple9(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple10(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10]) -> Semigroup[Tuple10[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple10(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10), Tuple10(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10)):
-        Tuple10(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10))
-  ))
+  combine_fn = ((Tuple10(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10)), (Tuple10(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10))) -> (
+    Tuple10(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple10(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10)), n) -> (
+      Tuple10(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple11(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11]) -> Semigroup[Tuple11[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple11(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11), Tuple11(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11)):
-        Tuple11(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11))
-  ))
+  combine_fn = ((Tuple11(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11)), (Tuple11(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11))) -> (
+    Tuple11(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple11(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11)), n) -> (
+      Tuple11(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple12(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12]) -> Semigroup[Tuple12[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple12(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12), Tuple12(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12)):
-        Tuple12(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12))
-  ))
+  combine_fn = ((Tuple12(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12)), (Tuple12(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12))) -> (
+    Tuple12(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple12(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12)), n) -> (
+      Tuple12(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple13(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13]) -> Semigroup[Tuple13[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple13(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13), Tuple13(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13)):
-        Tuple13(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13))
-  ))
+  combine_fn = ((Tuple13(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13)), (Tuple13(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13))) -> (
+    Tuple13(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple13(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13)), n) -> (
+      Tuple13(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple14(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14]) -> Semigroup[Tuple14[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple14(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14), Tuple14(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14)):
-        Tuple14(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14))
-  ))
+  combine_fn = ((Tuple14(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14)), (Tuple14(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14))) -> (
+    Tuple14(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple14(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14)), n) -> (
+      Tuple14(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple15(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15]) -> Semigroup[Tuple15[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple15(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15), Tuple15(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15)):
-        Tuple15(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15))
-  ))
+  combine_fn = ((Tuple15(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15)), (Tuple15(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15))) -> (
+    Tuple15(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)), n) -> (
+      Tuple15(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple16(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16]) -> Semigroup[Tuple16[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple16(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16), Tuple16(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16)):
-        Tuple16(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16))
-  ))
+  combine_fn = ((Tuple16(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16)), (Tuple16(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16))) -> (
+    Tuple16(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple16(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16)), n) -> (
+      Tuple16(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple17(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17]) -> Semigroup[Tuple17[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple17(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17), Tuple17(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17)):
-        Tuple17(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17))
-  ))
+  combine_fn = ((Tuple17(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17)), (Tuple17(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17))) -> (
+    Tuple17(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple17(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17)), n) -> (
+      Tuple17(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple18(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18]) -> Semigroup[Tuple18[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple18(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18), Tuple18(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18)):
-        Tuple18(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18))
-  ))
+  combine_fn = ((Tuple18(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18)), (Tuple18(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18))) -> (
+    Tuple18(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple18(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18)), n) -> (
+      Tuple18(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple19(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19]) -> Semigroup[Tuple19[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple19(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19), Tuple19(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19)):
-        Tuple19(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19))
-  ))
+  combine_fn = ((Tuple19(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19)), (Tuple19(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19))) -> (
+    Tuple19(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple19(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19)), n) -> (
+      Tuple19(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple20(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20]) -> Semigroup[Tuple20[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple20(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20), Tuple20(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20)):
-        Tuple20(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20))
-  ))
+  combine_fn = ((Tuple20(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20)), (Tuple20(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20))) -> (
+    Tuple20(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple20(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20)), n) -> (
+      Tuple20(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple21(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21]) -> Semigroup[Tuple21[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple21(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21), Tuple21(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21)):
-        Tuple21(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21))
-  ))
+  combine_fn = ((Tuple21(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21)), (Tuple21(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21))) -> (
+    Tuple21(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple21(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21)), n) -> (
+      Tuple21(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple22(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22]) -> Semigroup[Tuple22[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple22(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22), Tuple22(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22)):
-        Tuple22(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22))
-  ))
+  combine_fn = ((Tuple22(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22)), (Tuple22(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22))) -> (
+    Tuple22(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple22(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22)), n) -> (
+      Tuple22(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple23(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23]) -> Semigroup[Tuple23[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple23(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23), Tuple23(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23)):
-        Tuple23(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23))
-  ))
+  combine_fn = ((Tuple23(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23)), (Tuple23(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23))) -> (
+    Tuple23(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple23(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23)), n) -> (
+      Tuple23(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple24(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24]) -> Semigroup[Tuple24[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple24(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24), Tuple24(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24)):
-        Tuple24(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24))
-  ))
+  combine_fn = ((Tuple24(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24)), (Tuple24(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24))) -> (
+    Tuple24(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple24(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24)), n) -> (
+      Tuple24(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple25(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25]) -> Semigroup[Tuple25[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple25(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25), Tuple25(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25)):
-        Tuple25(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25))
-  ))
+  combine_fn = ((Tuple25(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25)), (Tuple25(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25))) -> (
+    Tuple25(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple25(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25)), n) -> (
+      Tuple25(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple26(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26]) -> Semigroup[Tuple26[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple26(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26), Tuple26(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26)):
-        Tuple26(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26))
-  ))
+  combine_fn = ((Tuple26(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26)), (Tuple26(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26))) -> (
+    Tuple26(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple26(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26)), n) -> (
+      Tuple26(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple27(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27]) -> Semigroup[Tuple27[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple27(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27), Tuple27(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27)):
-        Tuple27(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27))
-  ))
+  combine_fn = ((Tuple27(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27)), (Tuple27(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27))) -> (
+    Tuple27(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple27(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27)), n) -> (
+      Tuple27(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple28(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27], semigroup28: Semigroup[a28]) -> Semigroup[Tuple28[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple28(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28), Tuple28(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28)):
-        Tuple28(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28))
-  ))
+  combine_fn = ((Tuple28(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28)), (Tuple28(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28))) -> (
+    Tuple28(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple28(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27, value28)), n) -> (
+      Tuple28(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n), combine_n_positive_or_self(semigroup28, value28, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple29(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27], semigroup28: Semigroup[a28], semigroup29: Semigroup[a29]) -> Semigroup[Tuple29[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple29(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29), Tuple29(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29)):
-        Tuple29(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29))
-  ))
+  combine_fn = ((Tuple29(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29)), (Tuple29(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29))) -> (
+    Tuple29(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple29(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27, value28, value29)), n) -> (
+      Tuple29(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n), combine_n_positive_or_self(semigroup28, value28, n), combine_n_positive_or_self(semigroup29, value29, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple30(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27], semigroup28: Semigroup[a28], semigroup29: Semigroup[a29], semigroup30: Semigroup[a30]) -> Semigroup[Tuple30[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple30(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30), Tuple30(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30)):
-        Tuple30(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30))
-  ))
+  combine_fn = ((Tuple30(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30)), (Tuple30(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30))) -> (
+    Tuple30(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple30(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27, value28, value29, value30)), n) -> (
+      Tuple30(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n), combine_n_positive_or_self(semigroup28, value28, n), combine_n_positive_or_self(semigroup29, value29, n), combine_n_positive_or_self(semigroup30, value30, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple31(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27], semigroup28: Semigroup[a28], semigroup29: Semigroup[a29], semigroup30: Semigroup[a30], semigroup31: Semigroup[a31]) -> Semigroup[Tuple31[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple31(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30, left31), Tuple31(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30, right31)):
-        Tuple31(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30), combine_Semigroup(semigroup31, left31, right31))
-  ))
+  combine_fn = ((Tuple31(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30, left31)), (Tuple31(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30, right31))) -> (
+    Tuple31(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30), combine_Semigroup(semigroup31, left31, right31))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple31(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27, value28, value29, value30, value31)), n) -> (
+      Tuple31(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n), combine_n_positive_or_self(semigroup28, value28, n), combine_n_positive_or_self(semigroup29, value29, n), combine_n_positive_or_self(semigroup30, value30, n), combine_n_positive_or_self(semigroup31, value31, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def semigroup_Tuple32(semigroup1: Semigroup[a1], semigroup2: Semigroup[a2], semigroup3: Semigroup[a3], semigroup4: Semigroup[a4], semigroup5: Semigroup[a5], semigroup6: Semigroup[a6], semigroup7: Semigroup[a7], semigroup8: Semigroup[a8], semigroup9: Semigroup[a9], semigroup10: Semigroup[a10], semigroup11: Semigroup[a11], semigroup12: Semigroup[a12], semigroup13: Semigroup[a13], semigroup14: Semigroup[a14], semigroup15: Semigroup[a15], semigroup16: Semigroup[a16], semigroup17: Semigroup[a17], semigroup18: Semigroup[a18], semigroup19: Semigroup[a19], semigroup20: Semigroup[a20], semigroup21: Semigroup[a21], semigroup22: Semigroup[a22], semigroup23: Semigroup[a23], semigroup24: Semigroup[a24], semigroup25: Semigroup[a25], semigroup26: Semigroup[a26], semigroup27: Semigroup[a27], semigroup28: Semigroup[a28], semigroup29: Semigroup[a29], semigroup30: Semigroup[a30], semigroup31: Semigroup[a31], semigroup32: Semigroup[a32]) -> Semigroup[Tuple32[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32]]:
-  semigroup_from_combine((left, right) -> (
-    match (left, right):
-      case (Tuple32(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30, left31, left32), Tuple32(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30, right31, right32)):
-        Tuple32(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30), combine_Semigroup(semigroup31, left31, right31), combine_Semigroup(semigroup32, left32, right32))
-  ))
+  combine_fn = ((Tuple32(left1, left2, left3, left4, left5, left6, left7, left8, left9, left10, left11, left12, left13, left14, left15, left16, left17, left18, left19, left20, left21, left22, left23, left24, left25, left26, left27, left28, left29, left30, left31, left32)), (Tuple32(right1, right2, right3, right4, right5, right6, right7, right8, right9, right10, right11, right12, right13, right14, right15, right16, right17, right18, right19, right20, right21, right22, right23, right24, right25, right26, right27, right28, right29, right30, right31, right32))) -> (
+    Tuple32(combine_Semigroup(semigroup1, left1, right1), combine_Semigroup(semigroup2, left2, right2), combine_Semigroup(semigroup3, left3, right3), combine_Semigroup(semigroup4, left4, right4), combine_Semigroup(semigroup5, left5, right5), combine_Semigroup(semigroup6, left6, right6), combine_Semigroup(semigroup7, left7, right7), combine_Semigroup(semigroup8, left8, right8), combine_Semigroup(semigroup9, left9, right9), combine_Semigroup(semigroup10, left10, right10), combine_Semigroup(semigroup11, left11, right11), combine_Semigroup(semigroup12, left12, right12), combine_Semigroup(semigroup13, left13, right13), combine_Semigroup(semigroup14, left14, right14), combine_Semigroup(semigroup15, left15, right15), combine_Semigroup(semigroup16, left16, right16), combine_Semigroup(semigroup17, left17, right17), combine_Semigroup(semigroup18, left18, right18), combine_Semigroup(semigroup19, left19, right19), combine_Semigroup(semigroup20, left20, right20), combine_Semigroup(semigroup21, left21, right21), combine_Semigroup(semigroup22, left22, right22), combine_Semigroup(semigroup23, left23, right23), combine_Semigroup(semigroup24, left24, right24), combine_Semigroup(semigroup25, left25, right25), combine_Semigroup(semigroup26, left26, right26), combine_Semigroup(semigroup27, left27, right27), combine_Semigroup(semigroup28, left28, right28), combine_Semigroup(semigroup29, left29, right29), combine_Semigroup(semigroup30, left30, right30), combine_Semigroup(semigroup31, left31, right31), combine_Semigroup(semigroup32, left32, right32))
+  )
+  semigroup_specialized(
+    combine_fn,
+    ((Tuple32(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24, value25, value26, value27, value28, value29, value30, value31, value32)), n) -> (
+      Tuple32(combine_n_positive_or_self(semigroup1, value1, n), combine_n_positive_or_self(semigroup2, value2, n), combine_n_positive_or_self(semigroup3, value3, n), combine_n_positive_or_self(semigroup4, value4, n), combine_n_positive_or_self(semigroup5, value5, n), combine_n_positive_or_self(semigroup6, value6, n), combine_n_positive_or_self(semigroup7, value7, n), combine_n_positive_or_self(semigroup8, value8, n), combine_n_positive_or_self(semigroup9, value9, n), combine_n_positive_or_self(semigroup10, value10, n), combine_n_positive_or_self(semigroup11, value11, n), combine_n_positive_or_self(semigroup12, value12, n), combine_n_positive_or_self(semigroup13, value13, n), combine_n_positive_or_self(semigroup14, value14, n), combine_n_positive_or_self(semigroup15, value15, n), combine_n_positive_or_self(semigroup16, value16, n), combine_n_positive_or_self(semigroup17, value17, n), combine_n_positive_or_self(semigroup18, value18, n), combine_n_positive_or_self(semigroup19, value19, n), combine_n_positive_or_self(semigroup20, value20, n), combine_n_positive_or_self(semigroup21, value21, n), combine_n_positive_or_self(semigroup22, value22, n), combine_n_positive_or_self(semigroup23, value23, n), combine_n_positive_or_self(semigroup24, value24, n), combine_n_positive_or_self(semigroup25, value25, n), combine_n_positive_or_self(semigroup26, value26, n), combine_n_positive_or_self(semigroup27, value27, n), combine_n_positive_or_self(semigroup28, value28, n), combine_n_positive_or_self(semigroup29, value29, n), combine_n_positive_or_self(semigroup30, value30, n), combine_n_positive_or_self(semigroup31, value31, n), combine_n_positive_or_self(semigroup32, value32, n))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          Some(tail.foldl_List(head, combine_fn))
+    ),
+  )
 
 def eq_Dict(eq_key: Eq[k], eq_value: Eq[v]) -> Eq[Dict[k, v]]:
   pair_eq = eq_Tuple2(eq_key, eq_value)

--- a/src/Zafu/Abstract/Semigroup.bosatsu
+++ b/src/Zafu/Abstract/Semigroup.bosatsu
@@ -114,13 +114,49 @@ def reverse(inst: Semigroup[a]) -> Semigroup[a]:
   )
 
 def intercalate(inst: Semigroup[a], middle: a) -> Semigroup[a]:
-  semigroup_from_combine((left, right) -> combine(inst, combine(inst, left, middle), right))
+  Semigroup { combine_fn, combine_n_positive_fn, combine_all_option_fn, ... } = inst
+  semigroup_specialized(
+    (left, right) -> combine_fn(combine_fn(left, middle), right),
+    (value, n) -> (
+      if n.eq_Int(1):
+        value
+      else:
+        tail_value = combine_fn(middle, value)
+        combine_fn(value, combine_n_positive_fn(tail_value, n.sub(1)))
+    ),
+    (items) -> (
+      match items:
+        case []:
+          None
+        case [head, *tail]:
+          interleaved_rev = tail.foldl_List([head], (acc, item) -> [item, middle, *acc])
+          combine_all_option_fn(reverse_list(interleaved_rev))
+    ),
+  )
 
-def first() -> Semigroup[a]:
-  semigroup_from_combine((left, _) -> left)
+first: Semigroup[a] = semigroup_specialized(
+  (left, _) -> left,
+  (value, _) -> value,
+  (items) -> (
+    match items:
+      case []:
+        None
+      case [head, *_]:
+        Some(head)
+  ),
+)
 
-def last() -> Semigroup[a]:
-  semigroup_from_combine((_, right) -> right)
+last: Semigroup[a] = semigroup_specialized(
+  (_, right) -> right,
+  (value, _) -> value,
+  (items) -> (
+    match items:
+      case []:
+        None
+      case [head, *tail]:
+        Some(tail.foldl_List(head, (_, item) -> item))
+  ),
+)
 
 def laws_Semigroup(inst: Semigroup[a], eq_inst: Eq[a], x: a, y: a, z: a) -> Test:
   associative = Assertion(
@@ -174,11 +210,11 @@ tests = TestSuite("Semigroup tests", [
     Assertion(combine(inter, 1, 2).eq_Int(13), "intercalate")
   ),
   (
-    first_int = first()
+    first_int = first
     Assertion(combine(first_int, 1, 2).eq_Int(1), "first")
   ),
   (
-    last_int = last()
+    last_int = last
     Assertion(combine(last_int, 1, 2).eq_Int(2), "last")
   ),
   (


### PR DESCRIPTION
Implemented issue #59 per the merged design doc.

Changes made:
- Added new module `src/Zafu/Abstract/Semigroup.bosatsu` with:
  - `Semigroup` dictionary type
  - constructors: `semigroup_from_combine`, `semigroup_specialized`
  - core ops: `combine`, `combine_n`, `combine_all_option`
  - helpers: `maybe_combine_left`, `maybe_combine_right`
  - combinators: `reverse`, `intercalate`, `first`, `last`
  - law checker: `laws_Semigroup`
  - module tests covering laws and helper/combinator behavior (including large-`n` combine_n)
- Updated `src/Zafu/Abstract/Instances/Predef.bosatsu` to add Semigroup support:
  - imported Semigroup module
  - exported semigroup instances:
    - unambiguous: `semigroup_Unit`, `semigroup_String`, `semigroup_List`, `semigroup_Option`
    - ambiguous/suffixed: `semigroup_Bool_and`, `semigroup_Bool_or`, `semigroup_Int_add`, `semigroup_Int_mul`, `semigroup_Float64_add`, `semigroup_Float64_mul`
    - tuple family: `semigroup_Tuple1` through `semigroup_Tuple32`
  - added representative tests for primitive/structural semigroups and tuple low/high arity (`Tuple2`, `Tuple32`)

Validation run (all passing):
- `./bosatsu lib check`
- `./bosatsu lib test`
- `scripts/test.sh`

Also re-read the design doc and checked PR #60 discussion endpoints; there were no additional review comments to incorporate.

Fixes #59

Implements design doc: [docs/design/59-add-zafu-abstract-semigroup.md](https://github.com/johnynek/zafu/blob/main/docs/design/59-add-zafu-abstract-semigroup.md)

Design source PR: https://github.com/johnynek/zafu/pull/60