### PR TITLE
Remove redundant GT guards after LT|EQ checks

### DIFF
--- a/src/Zafu/Abstract/Semigroup.bosatsu
+++ b/src/Zafu/Abstract/Semigroup.bosatsu
@@ -34,7 +34,7 @@ def combine_n_positive_from_combine(combine_fn: (a, a) -> a, value: a, n: Int) -
     recur rem:
       case _ if cmp_Int(rem, 0) matches LT | EQ:
         acc
-      case _ if cmp_Int(rem, 0) matches GT:
+      case _:
         next_total = (
           if mod_Int(rem, 2).eq_Int(1):
             combine_fn(acc, power)
@@ -42,8 +42,6 @@ def combine_n_positive_from_combine(combine_fn: (a, a) -> a, value: a, n: Int) -
             acc
         )
         go(div(rem, 2), next_total, combine_fn(power, power))
-      case _:
-        acc
   go(n.sub(1), value, value)
 
 def combine_all_option_from_combine(combine_fn: (a, a) -> a, items: List[a]) -> Option[a]:

--- a/src/Zafu/Collection/Chain.bosatsu
+++ b/src/Zafu/Collection/Chain.bosatsu
@@ -156,7 +156,7 @@ def foldl_Chain(chain: Chain[a], init: b, fn: (b, a) -> b) -> b:
     recur rem:
       case _ if cmp_Int(rem, 0) matches LT | EQ:
         acc
-      case _ if cmp_Int(rem, 0) matches GT:
+      case _:
         match stack:
           case []:
             acc
@@ -170,8 +170,6 @@ def foldl_Chain(chain: Chain[a], init: b, fn: (b, a) -> b) -> b:
             loop_fold(rem.sub(1), tail, items.foldl_List(acc, fn))
           case [Concat(left, right), *tail]:
             loop_fold(rem.sub(1), [left, right, *tail], acc)
-      case _:
-        acc
   loop_fold(traversal_fuel(chain), [chain], init)
 
 def foldr_Array(items: Array[a], init: b, fn: (a, b) -> b) -> b:
@@ -187,7 +185,7 @@ def foldr_Chain(chain: Chain[a], init: b, fn: (a, b) -> b) -> b:
     recur rem:
       case _ if cmp_Int(rem, 0) matches LT | EQ:
         acc
-      case _ if cmp_Int(rem, 0) matches GT:
+      case _:
         match stack:
           case []:
             acc
@@ -201,8 +199,6 @@ def foldr_Chain(chain: Chain[a], init: b, fn: (a, b) -> b) -> b:
             loop_fold(rem.sub(1), tail, foldr_List_Chain(items, acc, fn))
           case [Concat(left, right), *tail]:
             loop_fold(rem.sub(1), [right, left, *tail], acc)
-      case _:
-        acc
   loop_fold(traversal_fuel(chain), [chain], init)
 
 # Convert to a list in iteration order.
@@ -217,7 +213,7 @@ def find_with_Chain(chain: Chain[a], idx: Int, on_missing: () -> b, on_found: a 
       recur rem:
         case _ if cmp_Int(rem, 0) matches LT | EQ:
           on_missing()
-        case _ if cmp_Int(rem, 0) matches GT:
+        case _:
           match stack:
             case []:
               on_missing()
@@ -250,8 +246,6 @@ def find_with_Chain(chain: Chain[a], idx: Int, on_missing: () -> b, on_found: a 
                 loop_find(rem.sub(1), tail, rem_idx.sub(cnt))
             case [Concat(left, right), *tail]:
               loop_find(rem.sub(1), [left, right, *tail], rem_idx)
-        case _:
-          on_missing()
     loop_find(traversal_fuel(chain), [chain], idx)
 
 # Option-returning index lookup.
@@ -388,10 +382,8 @@ def deep_concat_chain(size: Int) -> Chain[Int]:
     loop rem:
       case _ if cmp_Int(rem, 0) matches LT | EQ:
         acc
-      case _ if cmp_Int(rem, 0) matches GT:
-        loop_deep(rem.sub(1), concat_Chain(acc, singleton_Chain(rem)))
       case _:
-        acc
+        loop_deep(rem.sub(1), concat_Chain(acc, singleton_Chain(rem)))
   loop_deep(size, empty_Chain)
 
 rand_int: Rand[Int] = map_Rand(int_range(256), i -> i.sub(128))

--- a/src/Zafu/Collection/Vector.bosatsu
+++ b/src/Zafu/Collection/Vector.bosatsu
@@ -254,7 +254,7 @@ def find_with_Vector_loop(current: Vector[a], current_idx: Int, fuel: Int, on_mi
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       on_missing(Unit)
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match current:
         case Leaf(_, items):
           match get_Array(items, current_idx):
@@ -279,8 +279,6 @@ def find_with_Vector_loop(current: Vector[a], current_idx: Int, fuel: Int, on_mi
                     find_with_Vector_loop(child, local_idx, fuel.sub(1), on_missing, on_found)
                   case None:
                     on_missing(Unit)
-    case _:
-      on_missing()
 
 # Lookup helper used by both index_Vector and get_or_Vector.
 def find_with_Vector(vec: Vector[a], idx: Int, on_missing: () -> b, on_found: a -> b) -> b:
@@ -502,7 +500,7 @@ def append_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[a
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       from_List_Array([concat_fallback(vec, singleton_leaf(item))])
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match vec:
         case Leaf(sz, items):
           if cmp_Int(sz, chunk_width) matches LT:
@@ -533,14 +531,12 @@ def append_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[a
                 left_children = slice_Array(expanded_children, 0, chunk_width)
                 right_children = slice_Array(expanded_children, chunk_width, expanded_cnt)
                 from_List_Array([make_branch(height, left_children), make_branch(height, right_children)])
-    case _:
-      from_List_Array([concat_fallback(vec, singleton_leaf(item))])
 
 def prepend_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[a]]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       from_List_Array([concat_fallback(singleton_leaf(item), vec)])
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match vec:
         case Leaf(sz, items):
           if cmp_Int(sz, chunk_width) matches LT:
@@ -570,14 +566,12 @@ def prepend_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[
                 left_children = slice_Array(expanded_children, 0, chunk_width)
                 right_children = slice_Array(expanded_children, chunk_width, expanded_cnt)
                 from_List_Array([make_branch(height, left_children), make_branch(height, right_children)])
-    case _:
-      from_List_Array([concat_fallback(singleton_leaf(item), vec)])
 
 def updated_with_fuel_Vector(vec: Vector[a], idx: Int, item: a, fuel: Int) -> Option[Vector[a]]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       None
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match vec:
         case Leaf(sz, items):
           if cmp_Int(idx, 0) matches LT:
@@ -612,14 +606,12 @@ def updated_with_fuel_Vector(vec: Vector[a], idx: Int, item: a, fuel: Int) -> Op
                         case Some(next_child):
                           next_children = set_or_self_Array(children, child_idx, next_child)
                           Some(Branch(height, sz, prefix, next_children))
-    case _:
-      None
 
 def take_with_fuel_Vector(vec: Vector[a], count: Int, fuel: Int) -> Vector[a]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       empty_Vector
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match vec:
         case Leaf(_, items):
           taken = slice_Array(items, 0, count)
@@ -643,14 +635,12 @@ def take_with_fuel_Vector(vec: Vector[a], count: Int, fuel: Int) -> Vector[a]:
                 left_children = slice_Array(children, 0, child_idx)
                 kept_children = concat_all_Array([left_children, from_List_Array([child_taken])])
                 node_from_children(height, kept_children)
-    case _:
-      empty_Vector
 
 def drop_with_fuel_Vector(vec: Vector[a], count: Int, fuel: Int) -> Vector[a]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       empty_Vector
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match vec:
         case Leaf(_, items):
           sz = size_Array(items)
@@ -678,14 +668,12 @@ def drop_with_fuel_Vector(vec: Vector[a], count: Int, fuel: Int) -> Vector[a]:
                 else:
                   concat_all_Array([from_List_Array([child_kept]), right_children])
                 node_from_children(height, kept_children)
-    case _:
-      empty_Vector
 
 def next_leaf_Vector(stack: List[Vector[a]], fuel: Int) -> Option[(Array[a], List[Vector[a]])]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       None
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       match stack:
         case []:
           None
@@ -693,14 +681,12 @@ def next_leaf_Vector(stack: List[Vector[a]], fuel: Int) -> Option[(Array[a], Lis
           Some((items, tail))
         case [Branch(_, _, _, children), *tail]:
           next_leaf_Vector(push_children_ltr(children, tail), fuel.sub(1))
-    case _:
-      None
 
 def zip_chunk_with_fuel(left_items: Array[a], left_idx: Int, right_items: Array[b], right_idx: Int, rem: Int, rev_pairs: List[(a, b)]) -> (Int, Int, List[(a, b)]):
   recur rem:
     case _ if cmp_Int(rem, 0) matches LT | EQ:
       (left_idx, right_idx, rev_pairs)
-    case _ if cmp_Int(rem, 0) matches GT:
+    case _:
       match get_Array(left_items, left_idx):
         case None:
           (left_idx, right_idx, rev_pairs)
@@ -717,8 +703,6 @@ def zip_chunk_with_fuel(left_items: Array[a], left_idx: Int, right_items: Array[
                 rem.sub(1),
                 [(left_item, right_item), *rev_pairs]
               )
-    case _:
-      (left_idx, right_idx, rev_pairs)
 
 def zip_rev_with_fuel(left_stack: List[Vector[a]], right_stack: List[Vector[b]], left_curr: Option[(Array[a], Int)], right_curr: Option[(Array[b], Int)], rem: Int, rev_pairs: List[(a, b)], fuel: Int) -> List[(a, b)]:
   recur fuel:
@@ -726,7 +710,7 @@ def zip_rev_with_fuel(left_stack: List[Vector[a]], right_stack: List[Vector[b]],
       rev_pairs
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
       rev_pairs
-    case _ if cmp_Int(fuel, 0) matches GT:
+    case _:
       left_ready = match left_curr:
         case Some(curr):
           Some((curr, left_stack))
@@ -777,8 +761,6 @@ def zip_rev_with_fuel(left_stack: List[Vector[a]], right_stack: List[Vector[b]],
             )
         case _:
           rev_pairs
-    case _:
-      rev_pairs
 
 # Appends a single element to the end of a vector.
 def append_Vector(vec: Vector[a], item: a) -> Vector[a]:


### PR DESCRIPTION
Implemented issue #78 by removing needless `cmp_Int(..., 0) matches GT` guards when a prior branch already handles `LT | EQ`. Updated 14 occurrences across `src/Zafu/Abstract/Semigroup.bosatsu`, `src/Zafu/Collection/Chain.bosatsu`, and `src/Zafu/Collection/Vector.bosatsu` by switching the second branch to `case _` and deleting now-unreachable fallback `case _` branches. Ran required validation with `scripts/test.sh`; it passed.

Fixes #78