### PR TITLE
docs: rewrite markdown doc links to .html during pandoc conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
               --from=gfm \
               --to=html5 \
               --standalone \
+              --lua-filter scripts/rewrite_md_links.lua \
               --metadata "title=${rel_path%.md}" \
               --output "$html_path"
           done < <(find docs/markdown -type f -name '*.md' -print0)

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -80,6 +80,7 @@ jobs:
               --from=gfm \
               --to=html5 \
               --standalone \
+              --lua-filter scripts/rewrite_md_links.lua \
               --metadata "title=${rel_path%.md}" \
               --output "$html_path"
           done < <(find docs/markdown -type f -name '*.md' -print0)

--- a/scripts/rewrite_md_links.lua
+++ b/scripts/rewrite_md_links.lua
@@ -1,0 +1,24 @@
+-- Rewrite relative markdown links to html during pandoc conversion.
+-- Keeps absolute URLs and root-relative paths unchanged.
+function Link(el)
+  local target = el.target
+
+  if target:match("^[a-zA-Z][a-zA-Z0-9+%.%-]*:") then
+    return nil
+  end
+  if target:match("^/") then
+    return nil
+  end
+
+  local base, suffix = target:match("^([^?#]+)(.*)$")
+  if base == nil then
+    return nil
+  end
+
+  if base:match("%.md$") then
+    el.target = base:gsub("%.md$", ".html") .. suffix
+    return el
+  end
+
+  return nil
+end


### PR DESCRIPTION
## Summary
- add a Pandoc Lua filter at `scripts/rewrite_md_links.lua`
- rewrite only relative markdown links (`*.md`, preserving `#anchor`/`?query`) to `*.html`
- apply the filter in both docs conversion workflows:
  - `.github/workflows/docs-pages.yml`
  - `.github/workflows/ci.yml`

## Why
`./bosatsu lib doc` intentionally emits markdown links to other package docs as `.md`. The publish pipeline converts files to HTML, so without link rewriting those inter-doc links still point to non-published `.md` paths.

## Scope/Safety
- leaves absolute URLs (`https://...`, etc.) unchanged
- leaves root-relative links (`/...`) unchanged
- affects only HTML conversion via Pandoc filter, not generated markdown sources
