### PR TITLE
Optimize Vector.append with no-split fast path

### DIFF
--- a/src/Zafu/Collection/Vector.bosatsu
+++ b/src/Zafu/Collection/Vector.bosatsu
@@ -548,6 +548,32 @@ def append_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[a
                 right_children = slice_Array(expanded_children, chunk_width, expanded_cnt)
                 from_List_Array([make_branch(height, left_children), make_branch(height, right_children)])
 
+def append_no_split_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Option[Vector[a]]:
+  recur fuel:
+    case _ if cmp_Int(fuel, 0) matches LT | EQ:
+      None
+    case _:
+      match vec:
+        case Leaf(sz, items):
+          if cmp_Int(sz, chunk_width) matches LT:
+            new_items = concat_all_Array([items, from_List_Array([item])])
+            Some(Leaf(sz.add(1), new_items))
+          else:
+            None
+        case Branch(height, _, _, children):
+          cnt = size_Array(children)
+          if cnt.eq_Int(0):
+            None
+          else:
+            last_idx = cnt.sub(1)
+            child = get_or_Array(children, last_idx, _ -> empty)
+            match append_no_split_with_fuel(child, item, fuel.sub(1)):
+              case Some(next_child):
+                next_children = set_or_self_Array(children, last_idx, next_child)
+                Some(make_branch(height, next_children))
+              case None:
+                None
+
 def prepend_nodes_with_fuel(vec: Vector[a], item: a, fuel: Int) -> Array[Vector[a]]:
   recur fuel:
     case _ if cmp_Int(fuel, 0) matches LT | EQ:
@@ -780,14 +806,18 @@ def zip_rev_with_fuel(left_stack: List[Vector[a]], right_stack: List[Vector[b]],
 
 # Appends a single element to the end of a vector.
 def append(vec: Vector[a], item: a) -> Vector[a]:
-  nodes = append_nodes_with_fuel(vec, item, height(vec).add(8))
-  cnt = size_Array(nodes)
-  if cnt.eq_Int(0):
-    vec
-  elif cnt.eq_Int(1):
-    get_or_Array(nodes, 0, _ -> vec)
-  else:
-    make_branch(height(vec).add(1), nodes)
+  match append_no_split_with_fuel(vec, item, height(vec).add(8)):
+    case Some(next_vec):
+      next_vec
+    case None:
+      nodes = append_nodes_with_fuel(vec, item, height(vec).add(8))
+      cnt = size_Array(nodes)
+      if cnt.eq_Int(0):
+        vec
+      elif cnt.eq_Int(1):
+        get_or_Array(nodes, 0, _ -> vec)
+      else:
+        make_branch(height(vec).add(1), nodes)
 
 # Prepends a single element to the front of a vector.
 def prepend(vec: Vector[a], item: a) -> Vector[a]:


### PR DESCRIPTION
## Summary
- add an `append_no_split_with_fuel` fast path for `Vector.append`
- when the right spine can absorb one element without splitting, update only that path and rebuild prefixes via `make_branch`
- keep the existing `append_nodes_with_fuel` logic as fallback for split/grow cases

## Why
`append_one` was the primary C-priority benchmark target. The prior path always went through the generic node-growth machinery, even for the common no-split case.

## Benchmark notes (`./scripts/benchmark_vector.sh`, plus repeated C-only runs)
Baseline (`ops_per_us`, C `append_one`):
- size 1000: `0.272`
- size 10000: `0.187`
- size 100000: `0.143`

Observed with this change (representative runs):
- C, size 1000: repeatedly higher (`~0.389` to `~0.430`, about `+43%` to `+58%`)
- C, size 10000: often higher (`~0.211` to `~0.305`, about `+13%` to `+63%`), with occasional noisy regressions in throttled runs
- C, size 100000: mixed (`~0.100` to `~0.143`), no stable win signal

Non-append benchmark columns were noisy run-to-run and did not show a consistent algorithmic trend from this append-only change.

## Validation
- `./bosatsu lib check`
- `./bosatsu lib test`
