### PR TITLE
Pretty: return LazyList[String] from render APIs

### DIFF
--- a/src/Zafu/Text/Pretty.bosatsu
+++ b/src/Zafu/Text/Pretty.bosatsu
@@ -852,9 +852,8 @@ def render_stream_core(width: Int, doc: Doc, wide: Bool) -> LazyList[String]:
                   lazy(() -> loop_stream(next_fuel, pos, tail))
                 )
               case Line:
-                line_text = line_to_string(indent)
                 cons(
-                  lazy(() -> line_text),
+                  lazy(() -> line_to_string(indent)),
                   lazy(() -> loop_stream(next_fuel, max_Int(indent, 0), tail))
                 )
               case Union(_, flattened, fallback):


### PR DESCRIPTION
Implemented issue #109 in `src/Zafu/Text/Pretty.bosatsu` with focused API and renderer changes:
- Changed Pretty render function return types to `LazyList[String]`: `render`, `render_trim`, `render_stream`, `render_stream_trim`, and `render_wide_stream`.
- Refactored `render_stream_core` to emit chunks lazily via `LazyList.cons` with lazy tails instead of building strict `List[String]`.
- Added lazy trim streaming (`trim_stream`) so trimmed rendering also returns `LazyList[String]`.
- Removed now-unused strict trim helpers that produced full strings.
- Updated Pretty tests to compare lazy render output via a local `rendered_to_string`/`eq_rendered` helper, keeping behavioral assertions intact.

Validation:
- Ran required command `scripts/test.sh` successfully (passes, including `Zafu/Text/Pretty` tests).

Fixes #109