### PR TITLE
Implement PartialResult API and law/tests for issue #107

### DIFF
--- a/src/Zafu/Control/PartialResult.bosatsu
+++ b/src/Zafu/Control/PartialResult.bosatsu
@@ -80,22 +80,10 @@ def is_total_ok(result: PartialResult[e, a]) -> Bool:
   result matches TotalOk(_)
 
 def has_err(result: PartialResult[e, a]) -> Bool:
-  match result:
-    case TotalErr(_):
-      True
-    case PartialErr(_, _):
-      True
-    case TotalOk(_):
-      False
+  result matches TotalErr(_) | PartialErr(_, _)
 
 def has_ok(result: PartialResult[e, a]) -> Bool:
-  match result:
-    case TotalErr(_):
-      False
-    case PartialErr(_, _):
-      True
-    case TotalOk(_):
-      True
+  result matches PartialErr(_, _) | TotalOk(_)
 
 def err(result: PartialResult[e, a]) -> Option[e]:
   match result:
@@ -160,10 +148,8 @@ def or_else(result: PartialResult[e, a], fn: e -> PartialResult[e, a]) -> Partia
   match result:
     case TotalErr(err_value):
       fn(err_value)
-    case PartialErr(err_value, partial_value):
-      PartialErr(err_value, partial_value)
-    case TotalOk(ok_value):
-      TotalOk(ok_value)
+    case _:
+      result
 
 def fold(
   result: PartialResult[e, a],
@@ -262,10 +248,7 @@ def combine_map2(
   right: PartialResult[e, b],
   fn: (a, b) -> c,
 ) -> PartialResult[e, c]:
-  map(combine_product(semi, left, right), pair -> (
-    (left_value, right_value) = pair
-    fn(left_value, right_value)
-  ))
+  map(combine_product(semi, left, right), ((left_value, right_value)) -> fn(left_value, right_value))
 
 def combine_product_l(
   semi: Semigroup[e],
@@ -517,10 +500,7 @@ tests = TestSuite("PartialResult tests", [
     left = PartialErr(1, 2)
     right = PartialErr(3, 4)
     via_map2 = combine_map2(int_add_semigroup, left, right, add)
-    via_product = map(combine_product(int_add_semigroup, left, right), pair -> (
-      (left_value, right_value) = pair
-      add(left_value, right_value)
-    ))
+    via_product = map(combine_product(int_add_semigroup, left, right), ((left_value, right_value)) -> add(left_value, right_value))
     Assertion(eq_Eq(inst, via_map2, via_product), "combine_map2 consistent with combine_product")
   ),
   Assertion(


### PR DESCRIPTION
Implemented `src/Zafu/Control/PartialResult.bosatsu` per the merged design doc.

What changed:
- Added `PartialResult[e, a]` with constructors:
  - `TotalErr(err: e)`
  - `PartialErr(err: e, partial: a)`
  - `TotalOk(ok: a)`
- Implemented and exported the full designed API:
  - predicates/views: `is_total_err`, `is_partial_err`, `is_total_ok`, `has_err`, `has_ok`, `err`, `ok`, `to_Option`
  - transforms: `map`, `map_err`
  - sequential composition: `and_then`, `flat_map` (Semigroup-aware)
  - recovery/elimination: `or_else`, `fold`, `unwrap_or`, `unwrap_or_else`, `unwrap`
  - conversions: `from_Option`, `from_Result`, `to_Result_fail_fast`
  - product composition: `combine_product`, `combine_map2`, `combine_product_l`, `combine_product_r`
  - adapters: `eq`, `ord`, `hash` (constructor-sensitive)
- Added concise comments around subtle accumulation logic in `and_then` and `combine_product`.
- Added comprehensive in-module tests (80 assertions), including:
  - coverage across constructors for core APIs (`map`, `map_err`, `fold`, `unwrap_or`, `unwrap_or_else`, `unwrap`, conversions)
  - all 9 `combine_product` constructor pairings from the design table
  - `combine_map2` behavior and consistency with `combine_product` + `map`
  - monad law checks for `and_then` (left/right identity, associativity) under a fixed lawful non-trivial semigroup (`List[Int]` concatenation)
  - constructor-sensitive `eq`/`ord`/`hash` checks
  - fail-fast conversion check: `to_Result_fail_fast(PartialErr(e, a)) == Err(e)`

Validation run:
- `./bosatsu lib check` passed
- `./bosatsu lib test` passed
- `scripts/test.sh` passed

Scope note:
- No `Result` module changes were required; the optional symmetric helper in `Result` was left deferred as optional in the design.

Fixes #107

Implements design doc: [docs/design/107-design-a-partialresult-class.md](https://github.com/johnynek/zafu/blob/main/docs/design/107-design-a-partialresult-class.md)

Design source PR: https://github.com/johnynek/zafu/pull/110