### PR TITLE
Preserve eval passthrough delimiter in launcher

### DIFF
--- a/bosatsu
+++ b/bosatsu
@@ -63,6 +63,7 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --)
+      args+=("--")
       shift
       args+=("$@")
       break

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+./scripts/test_launcher_passthrough.sh
 ./bosatsu --fetch > /dev/null
 ./bosatsu lib fetch
 ./bosatsu lib check

--- a/scripts/test_launcher_passthrough.sh
+++ b/scripts/test_launcher_passthrough.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+TMPDIR_ROOT="${TMPDIR:-/tmp}"
+WORKDIR="$(mktemp -d "${TMPDIR_ROOT%/}/zafu-launcher-test.XXXXXX")"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+TEST_REPO="$WORKDIR/repo"
+mkdir -p "$TEST_REPO/.git"
+cp "$REPO_ROOT/bosatsu" "$TEST_REPO/bosatsu"
+chmod +x "$TEST_REPO/bosatsu"
+printf 'test-version\n' > "$TEST_REPO/.bosatsu_version"
+printf 'native\n' > "$TEST_REPO/.bosatsu_platform"
+
+FAKE_ARTIFACT="$WORKDIR/fake-bosatsu"
+cat > "$FAKE_ARTIFACT" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$PWD/argv.txt"
+EOF
+chmod +x "$FAKE_ARTIFACT"
+
+(
+  cd "$TEST_REPO"
+  ./bosatsu \
+    --artifact "$FAKE_ARTIFACT" \
+    lib eval --main Zafu/Tool/JsonFormat::main --run -- --compact
+)
+
+EXPECTED="$WORKDIR/expected.txt"
+cat > "$EXPECTED" <<'EOF'
+lib
+eval
+--main
+Zafu/Tool/JsonFormat::main
+--run
+--
+--compact
+EOF
+
+if ! cmp -s "$EXPECTED" "$TEST_REPO/argv.txt"; then
+  echo "launcher did not preserve the eval passthrough delimiter" >&2
+  diff -u "$EXPECTED" "$TEST_REPO/argv.txt" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- preserve the explicit `--` delimiter when the checked-in `./bosatsu` launcher forwards eval args
- add a launcher regression script that exercises `lib eval --run -- --compact`
- run that regression script from `scripts/test.sh`

## Problem
Bosatsu core already supports `lib eval --run -- --compact`, but Zafu's checked-in launcher was stripping the first `--` before execing the pinned CLI artifact. That turned:

```sh
./bosatsu lib eval --main Zafu/Tool/JsonFormat::main --run -- --compact
```

into:

```sh
./bosatsu lib eval --main Zafu/Tool/JsonFormat::main --run --compact
```

which explains the observed `Unexpected option: --compact` failure.

## Testing
- `./scripts/test_launcher_passthrough.sh`
- `scripts/test.sh` (validated in a plain git clone of this branch)
