### PR TITLE
Roadmap revision for #166 (v2)

### DIFF
--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
@@ -1,108 +1,120 @@
 {
   "nodes": [
     {
-      "body_markdown": "Build the shared benchmark-game support layer that all benchmark implementations will use.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.\n- Keep algorithm kernels and I/O wrappers separate so later benchmark nodes can reach full test coverage with thin `main` values and heavily tested pure helpers.\n- Add focused tests for every new helper, including CLI parsing, row formatting, fixture normalization, and error-reporting paths.\n- Do not implement any specific benchmarksgame algorithm in this node.\n\n## Acceptance Criteria\n- Later benchmark nodes can depend on a shipped common layer instead of duplicating CLI or result-format logic.\n- New common modules are fully exercised by repo tests and fit existing Bosatsu style.\n- `scripts/test.sh` passes.",
+      "body_markdown": "Build the shared benchmark-game support layer that all benchmark implementations will use.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.\n- Keep algorithm kernels and I/O wrappers separate so later benchmark nodes can reach full test coverage with thin `main` values and heavily tested pure helpers.\n- Add focused tests for every new helper, including CLI parsing, row formatting, fixture normalization, and error-reporting paths.\n- Do not implement any specific benchmarksgame algorithm in this node.\n\n## Acceptance Criteria\n- Later benchmark nodes can depend on a shipped common layer instead of duplicating CLI or result-format logic.\n- New common modules are fully exercised by repo tests and fit existing Bosatsu style.\n- `scripts/test.sh` passes.",
       "depends_on": [
         {
-          "node_id": "suite_spec",
+          "node_id": "suite_contract_doc",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "bench_common",
+      "node_id": "bench_common_v2",
       "title": "Add shared benchmark game harness utilities"
     },
     {
-      "body_markdown": "Implement `mandelbrot` with exact portable-bitmap output.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame rectangle, escape limit, CLI contract, and byte-for-byte PBM output format from the suite spec.\n- Keep byte packing and header emission testable as pure functions; use checked-in fixtures for validation instead of ad hoc shell diff logic.\n- Add sample-output tests covering header formatting, row packing, and the official validation case.\n\n## Acceptance Criteria\n- Output matches the official validation fixture for the chosen sample input.\n- The executable runs on both Bosatsu JVM and C targets.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.",
+      "body_markdown": "Implement `mandelbrot` with exact portable-bitmap output.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame rectangle, escape limit, CLI contract, and byte-for-byte PBM output format from the suite spec.\n- Keep byte packing and header emission testable as pure functions; use checked-in fixtures for validation instead of ad hoc shell diff logic.\n- Add sample-output tests covering header formatting, row packing, and the official validation case.\n\n## Acceptance Criteria\n- Output matches the official validation fixture for the chosen sample input.\n- The executable runs on both Bosatsu JVM and C targets.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.",
       "depends_on": [
         {
-          "node_id": "bench_common",
+          "node_id": "bench_common_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_spec",
+          "node_id": "suite_contract_doc",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "bitmap_output",
+      "node_id": "bitmap_output_v2",
       "title": "Implement the mandelbrot benchmark program"
     },
     {
-      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.\n- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.\n- Reference program provenance is explicit and reproducible.\n- Result normalization is tested, and the repo test suite remains green.",
+      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v2` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v2` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v2` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v2` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.\n- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.\n- Reference program provenance is explicit and reproducible.\n- Result normalization is tested, and the repo test suite remains green.",
       "depends_on": [
         {
-          "node_id": "bench_common",
+          "node_id": "bench_common_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "bitmap_output",
+          "node_id": "bitmap_output_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "numeric_kernels",
+          "node_id": "numeric_kernels_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "structural_kernels",
+          "node_id": "structural_kernels_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_spec",
+          "node_id": "suite_contract_doc",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "compare_harness",
+      "node_id": "compare_harness_v2",
       "title": "Vendor Java and C baselines and add the comparison runner"
     },
     {
-      "body_markdown": "Document the workflow and check in a first reproducible local baseline.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.\n- `scripts/test.sh` stays green.",
+      "body_markdown": "Document the workflow and check in a first reproducible local baseline.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v2` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.\n- `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "compare_harness",
+          "node_id": "compare_harness_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_spec",
+          "node_id": "suite_contract_doc",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "docs_baseline",
+      "node_id": "docs_baseline_v2",
       "title": "Document the benchmark workflow and capture a first baseline"
     },
     {
-      "body_markdown": "Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame algorithms, CLI shape, validation output, and large-N performance inputs recorded in the suite spec.\n- Prefer pure helpers for state stepping, matrix-vector math, formatting, and output verification so behavior is testable without shelling out.\n- Add exact sample-output tests for the official small-N validation cases, plus targeted tests for numerical invariants and formatting paths.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
+      "body_markdown": "Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame algorithms, CLI shape, validation output, and large-N performance inputs recorded in the suite spec.\n- Prefer pure helpers for state stepping, matrix-vector math, formatting, and output verification so behavior is testable without shelling out.\n- Add exact sample-output tests for the official small-N validation cases, plus targeted tests for numerical invariants and formatting paths.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "bench_common",
+          "node_id": "bench_common_v2",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_spec",
+          "node_id": "suite_contract_doc",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "numeric_kernels",
+      "node_id": "numeric_kernels_v2",
       "title": "Implement n-body and spectral-norm benchmark programs"
     },
     {
-      "body_markdown": "Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.\n- Follow the suite spec and benchmarksgame constraints exactly, including checksum rules, permutation ordering, and binary-tree work requirements; do not introduce custom allocators or benchmark-specific shortcuts that the spec rejects.\n- Keep tree building, tree checking, permutation generation, and output formatting testable as pure code.\n- Add exact sample-output tests for the official small-N validation cases, plus focused tests for checksum, max-flip, and tree-check behavior.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
+      "body_markdown": "Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.\n\n## Direct Inputs\n- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.\n- Follow the suite spec and benchmarksgame constraints exactly, including checksum rules, permutation ordering, and binary-tree work requirements; do not introduce custom allocators or benchmark-specific shortcuts that the spec rejects.\n- Keep tree building, tree checking, permutation generation, and output formatting testable as pure code.\n- Add exact sample-output tests for the official small-N validation cases, plus focused tests for checksum, max-flip, and tree-check behavior.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "bench_common",
+          "node_id": "bench_common_v2",
           "requires": "implemented"
         },
+        {
+          "node_id": "suite_contract_doc",
+          "requires": "planned"
+        }
+      ],
+      "kind": "small_job",
+      "node_id": "structural_kernels_v2",
+      "title": "Implement binary-trees and fannkuch-redux benchmark programs"
+    },
+    {
+      "body_markdown": "Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` so downstream implementation nodes have the exact contract file they are supposed to consume.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.\n\n## Scope\n- Author `docs/design/166-benchmarksgame-suite.md` from the merged design contract without widening scope beyond the already reviewed benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.\n- Keep this issue doc-only: add the concrete suite-spec artifact and any minimal doc cross-links needed for clarity, but do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n- Make the new suite-spec doc self-contained so later workers can rely on that exact file path instead of reconstructing intent from the higher-level design artifact.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.\n- The doc names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.\n- The child issue lands only the concrete suite-spec doc artifact.",
+      "depends_on": [
         {
           "node_id": "suite_spec",
           "requires": "planned"
         }
       ],
-      "kind": "small_job",
-      "node_id": "structural_kernels",
-      "title": "Implement binary-trees and fannkuch-redux benchmark programs"
+      "kind": "reference_doc",
+      "node_id": "suite_contract_doc",
+      "title": "Author the concrete benchmark game suite spec document"
     },
     {
       "body_markdown": "Write the durable suite specification for issue #166 in `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Choose the phase-1 benchmark set for zafu. The default target should be `n-body`, `spectral-norm`, `binary-trees`, `fannkuch-redux`, and `mandelbrot`, and the doc should explicitly record why `k-nucleotide`, `reverse-complement`, `regex-redux`, `fasta`, and `pidigits` are out of scope for this issue.\n- For each chosen benchmark, record the benchmarksgame description URL, the official sample-output validation source, the large-N performance input, the expected CLI contract, and the exact Java and C reference programs we will compare against.\n- Define repo conventions for phase-1 code layout under `src/Zafu/Benchmark/Game/`, fixture storage, vendored baseline source storage, and comparison result artifacts.\n- Define the single-machine comparison protocol for Bosatsu JVM, Bosatsu C, Java, and C, including warmup policy, repeat policy, metadata capture, and explicit caveats about local runs versus benchmarksgame's BenchExec measurements.\n\n## Acceptance Criteria\n- The doc is self-contained enough that downstream workers do not need to rediscover benchmark pages or guess command lines.\n- The doc names every planned source path or directory that later nodes will touch.\n- The child issue lands only the reviewed doc artifact; no implementation work is mixed into this PR.",
@@ -113,5 +125,5 @@
     }
   ],
   "roadmap_issue_number": 166,
-  "version": 1
+  "version": 2
 }

--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
@@ -7,18 +7,19 @@
 ## Metadata
 
 - Roadmap issue: `#166`
-- Graph version: `1`
-- Node count: `7`
+- Graph version: `2`
+- Node count: `8`
 
 ## Dependency Overview
 
 1. `suite_spec` (`reference_doc`): none
-2. `bench_common` (`small_job`): `suite_spec` (`planned`)
-3. `bitmap_output` (`small_job`): `bench_common` (`implemented`), `suite_spec` (`planned`)
-4. `numeric_kernels` (`small_job`): `bench_common` (`implemented`), `suite_spec` (`planned`)
-5. `structural_kernels` (`small_job`): `bench_common` (`implemented`), `suite_spec` (`planned`)
-6. `compare_harness` (`small_job`): `bench_common` (`implemented`), `bitmap_output` (`implemented`), `numeric_kernels` (`implemented`), `structural_kernels` (`implemented`), `suite_spec` (`planned`)
-7. `docs_baseline` (`small_job`): `compare_harness` (`implemented`), `suite_spec` (`planned`)
+2. `suite_contract_doc` (`reference_doc`): `suite_spec` (`planned`)
+3. `bench_common_v2` (`small_job`): `suite_contract_doc` (`planned`)
+4. `bitmap_output_v2` (`small_job`): `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
+5. `numeric_kernels_v2` (`small_job`): `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
+6. `structural_kernels_v2` (`small_job`): `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
+7. `compare_harness_v2` (`small_job`): `bench_common_v2` (`implemented`), `bitmap_output_v2` (`implemented`), `numeric_kernels_v2` (`implemented`), `structural_kernels_v2` (`implemented`), `suite_contract_doc` (`planned`)
+8. `docs_baseline_v2` (`small_job`): `compare_harness_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 ## Nodes
 
@@ -43,18 +44,41 @@ Write the durable suite specification for issue #166 in `docs/design/166-benchma
 - The doc names every planned source path or directory that later nodes will touch.
 - The child issue lands only the reviewed doc artifact; no implementation work is mixed into this PR.
 
-### `bench_common`
+### `suite_contract_doc`
+
+- Kind: `reference_doc`
+- Title: Author the concrete benchmark game suite spec document
+- Depends on: `suite_spec` (`planned`)
+
+#### Body
+
+Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` so downstream implementation nodes have the exact contract file they are supposed to consume.
+
+## Direct Inputs
+- `suite_spec` (`planned`): the merged design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.
+
+## Scope
+- Author `docs/design/166-benchmarksgame-suite.md` from the merged design contract without widening scope beyond the already reviewed benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.
+- Keep this issue doc-only: add the concrete suite-spec artifact and any minimal doc cross-links needed for clarity, but do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.
+- Make the new suite-spec doc self-contained so later workers can rely on that exact file path instead of reconstructing intent from the higher-level design artifact.
+
+## Acceptance Criteria
+- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.
+- The doc names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.
+- The child issue lands only the concrete suite-spec doc artifact.
+
+### `bench_common_v2`
 
 - Kind: `small_job`
 - Title: Add shared benchmark game harness utilities
-- Depends on: `suite_spec` (`planned`)
+- Depends on: `suite_contract_doc` (`planned`)
 
 #### Body
 
 Build the shared benchmark-game support layer that all benchmark implementations will use.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
 
 ## Scope
 - Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.
@@ -67,19 +91,19 @@ Build the shared benchmark-game support layer that all benchmark implementations
 - New common modules are fully exercised by repo tests and fit existing Bosatsu style.
 - `scripts/test.sh` passes.
 
-### `bitmap_output`
+### `bitmap_output_v2`
 
 - Kind: `small_job`
 - Title: Implement the mandelbrot benchmark program
-- Depends on: `bench_common` (`implemented`), `suite_spec` (`planned`)
+- Depends on: `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 #### Body
 
 Implement `mandelbrot` with exact portable-bitmap output.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.
@@ -92,19 +116,19 @@ Implement `mandelbrot` with exact portable-bitmap output.
 - The executable runs on both Bosatsu JVM and C targets.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.
 
-### `numeric_kernels`
+### `numeric_kernels_v2`
 
 - Kind: `small_job`
 - Title: Implement n-body and spectral-norm benchmark programs
-- Depends on: `bench_common` (`implemented`), `suite_spec` (`planned`)
+- Depends on: `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 #### Body
 
 Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.
@@ -117,19 +141,19 @@ Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.
 - Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.
 
-### `structural_kernels`
+### `structural_kernels_v2`
 
 - Kind: `small_job`
 - Title: Implement binary-trees and fannkuch-redux benchmark programs
-- Depends on: `bench_common` (`implemented`), `suite_spec` (`planned`)
+- Depends on: `bench_common_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 #### Body
 
 Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v2` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.
@@ -142,22 +166,22 @@ Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and 
 - Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.
 
-### `compare_harness`
+### `compare_harness_v2`
 
 - Kind: `small_job`
 - Title: Vendor Java and C baselines and add the comparison runner
-- Depends on: `bench_common` (`implemented`), `bitmap_output` (`implemented`), `numeric_kernels` (`implemented`), `structural_kernels` (`implemented`), `suite_spec` (`planned`)
+- Depends on: `bench_common_v2` (`implemented`), `bitmap_output_v2` (`implemented`), `numeric_kernels_v2` (`implemented`), `structural_kernels_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 #### Body
 
 Vendor the comparison baselines and make local cross-language runs reproducible.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common` (`implemented`): the shipped benchmark-game result schema and shared helpers.
-- `numeric_kernels` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
-- `structural_kernels` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
-- `bitmap_output` (`implemented`): the shipped Bosatsu `mandelbrot` program.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v2` (`implemented`): the shipped benchmark-game result schema and shared helpers.
+- `numeric_kernels_v2` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
+- `structural_kernels_v2` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
+- `bitmap_output_v2` (`implemented`): the shipped Bosatsu `mandelbrot` program.
 
 ## Scope
 - Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.
@@ -170,19 +194,19 @@ Vendor the comparison baselines and make local cross-language runs reproducible.
 - Reference program provenance is explicit and reproducible.
 - Result normalization is tested, and the repo test suite remains green.
 
-### `docs_baseline`
+### `docs_baseline_v2`
 
 - Kind: `small_job`
 - Title: Document the benchmark workflow and capture a first baseline
-- Depends on: `compare_harness` (`implemented`), `suite_spec` (`planned`)
+- Depends on: `compare_harness_v2` (`implemented`), `suite_contract_doc` (`planned`)
 
 #### Body
 
 Document the workflow and check in a first reproducible local baseline.
 
 ## Direct Inputs
-- `suite_spec` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `compare_harness` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.
+- `suite_contract_doc` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `compare_harness_v2` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.
 
 ## Scope
 - Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.


### PR DESCRIPTION
Automated same-roadmap revision.

- target graph version: `2`
- roadmap doc path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md`
- graph path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json`
- summary: Revise the roadmap before issuing more child work: the current ready frontier `bench_common` assumes a concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md`, but the only merged upstream artifact is the higher-level design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.

The roadmap is still viable, and the benchmark grouping plus later sequencing remain sound, so this is not an abandonment case. However, the current ready frontier is materially wrong for the handoff contract. `suite_spec` is marked completed through issue #168 / PR #169, but on `main` that work produced only `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`. The downstream pending nodes all declare a direct input of the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`, and that file does not exist. Because downstream workers must receive exact direct dependency artifacts without reconstructing intent, `bench_common` should pause. The revision inserts a doc-only `suite_contract_doc` node that turns the merged design contract into the concrete `docs/design/166-benchmarksgame-suite.md` artifact, then rewires the pending implementation nodes to depend directly on that new artifact and on the revised shared-harness node. This preserves the completed `suite_spec` work, keeps the implementation fan-out and comparison/docs tail intact, and changes the effective ready frontier from `bench_common` to `suite_contract_doc`.

Refs #166