### PR TITLE
Roadmap revision for #166 (v4)

### DIFF
--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
@@ -1,107 +1,107 @@
 {
   "nodes": [
     {
-      "body_markdown": "Build the shared benchmark-game support layer that all benchmark implementations will use.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.\n- Keep algorithm kernels and I/O wrappers separate so later benchmark nodes can reach full test coverage with thin `main` values and heavily tested pure helpers.\n- Add focused tests for every new helper, including CLI parsing, row formatting, fixture normalization, and error-reporting paths.\n- Do not implement any specific benchmarksgame algorithm in this node.\n\n## Acceptance Criteria\n- Later benchmark nodes can depend on a shipped common layer instead of duplicating CLI or result-format logic.\n- New common modules are fully exercised by repo tests and fit existing Bosatsu style.\n- `scripts/test.sh` passes.",
+      "body_markdown": "Build the shared benchmark-game support layer that all benchmark implementations will use.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.\n- Keep algorithm kernels and I/O wrappers separate so later benchmark nodes can reach full test coverage with thin `main` values and heavily tested pure helpers.\n- Add focused tests for every new helper, including CLI parsing, row formatting, fixture normalization, and error-reporting paths.\n- Do not implement any specific benchmarksgame algorithm in this node.\n\n## Acceptance Criteria\n- Later benchmark nodes can depend on a shipped common layer instead of duplicating CLI or result-format logic.\n- New common modules are fully exercised by repo tests and fit existing Bosatsu style.\n- `scripts/test.sh` passes.",
       "depends_on": [
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "bench_common_v3",
+      "node_id": "bench_common_v4",
       "title": "Add shared benchmark game harness utilities"
     },
     {
-      "body_markdown": "Implement `mandelbrot` with exact portable-bitmap output.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame rectangle, escape limit, CLI contract, and byte-for-byte PBM output format from the suite spec.\n- Keep byte packing and header emission testable as pure functions; use checked-in fixtures for validation instead of ad hoc shell diff logic.\n- Add sample-output tests covering header formatting, row packing, and the official validation case.\n\n## Acceptance Criteria\n- Output matches the official validation fixture for the chosen sample input.\n- The executable runs on both Bosatsu JVM and C targets.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.",
+      "body_markdown": "Implement `mandelbrot` with exact portable-bitmap output.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame rectangle, escape limit, CLI contract, and byte-for-byte PBM output format from the suite spec.\n- Keep byte packing and header emission testable as pure functions; use checked-in fixtures for validation instead of ad hoc shell diff logic.\n- Add sample-output tests covering header formatting, row packing, and the official validation case.\n\n## Acceptance Criteria\n- Output matches the official validation fixture for the chosen sample input.\n- The executable runs on both Bosatsu JVM and C targets.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.",
       "depends_on": [
         {
-          "node_id": "bench_common_v3",
+          "node_id": "bench_common_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "bitmap_output_v3",
+      "node_id": "bitmap_output_v4",
       "title": "Implement the mandelbrot benchmark program"
     },
     {
-      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v3` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v3` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v3` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v3` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.\n- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.\n- Reference program provenance is explicit and reproducible.\n- Result normalization is tested, and the repo test suite remains green.",
+      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.\n- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.\n- Reference program provenance is explicit and reproducible.\n- Result normalization is tested, and the repo test suite remains green.",
       "depends_on": [
         {
-          "node_id": "bench_common_v3",
+          "node_id": "bench_common_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "bitmap_output_v3",
+          "node_id": "bitmap_output_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "numeric_kernels_v3",
+          "node_id": "numeric_kernels_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "structural_kernels_v3",
+          "node_id": "structural_kernels_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "compare_harness_v3",
+      "node_id": "compare_harness_v4",
       "title": "Vendor Java and C baselines and add the comparison runner"
     },
     {
-      "body_markdown": "Document the workflow and check in a first reproducible local baseline.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v3` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.\n- `scripts/test.sh` stays green.",
+      "body_markdown": "Document the workflow and check in a first reproducible local baseline.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v4` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.\n- `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "compare_harness_v3",
+          "node_id": "compare_harness_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "docs_baseline_v3",
+      "node_id": "docs_baseline_v4",
       "title": "Document the benchmark workflow and capture a first baseline"
     },
     {
-      "body_markdown": "Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame algorithms, CLI shape, validation output, and large-N performance inputs recorded in the suite spec.\n- Prefer pure helpers for state stepping, matrix-vector math, formatting, and output verification so behavior is testable without shelling out.\n- Add exact sample-output tests for the official small-N validation cases, plus targeted tests for numerical invariants and formatting paths.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
+      "body_markdown": "Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame algorithms, CLI shape, validation output, and large-N performance inputs recorded in the suite spec.\n- Prefer pure helpers for state stepping, matrix-vector math, formatting, and output verification so behavior is testable without shelling out.\n- Add exact sample-output tests for the official small-N validation cases, plus targeted tests for numerical invariants and formatting paths.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "bench_common_v3",
+          "node_id": "bench_common_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "numeric_kernels_v3",
+      "node_id": "numeric_kernels_v4",
       "title": "Implement n-body and spectral-norm benchmark programs"
     },
     {
-      "body_markdown": "Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.\n- Follow the suite spec and benchmarksgame constraints exactly, including checksum rules, permutation ordering, and binary-tree work requirements; do not introduce custom allocators or benchmark-specific shortcuts that the spec rejects.\n- Keep tree building, tree checking, permutation generation, and output formatting testable as pure code.\n- Add exact sample-output tests for the official small-N validation cases, plus focused tests for checksum, max-flip, and tree-check behavior.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
+      "body_markdown": "Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.\n- Follow the suite spec and benchmarksgame constraints exactly, including checksum rules, permutation ordering, and binary-tree work requirements; do not introduce custom allocators or benchmark-specific shortcuts that the spec rejects.\n- Keep tree building, tree checking, permutation generation, and output formatting testable as pure code.\n- Add exact sample-output tests for the official small-N validation cases, plus focused tests for checksum, max-flip, and tree-check behavior.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "bench_common_v3",
+          "node_id": "bench_common_v4",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v2",
+          "node_id": "suite_contract_artifact_v3",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "structural_kernels_v3",
+      "node_id": "structural_kernels_v4",
       "title": "Implement binary-trees and fannkuch-redux benchmark programs"
     },
     {
@@ -115,6 +115,18 @@
       "kind": "reference_doc",
       "node_id": "suite_contract_artifact_v2",
       "title": "Create the missing concrete benchmark game suite spec artifact"
+    },
+    {
+      "body_markdown": "Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` on the default branch so downstream implementation nodes can consume the promised contract file directly.\n\n## Direct Inputs\n- `suite_contract_artifact_v2` (`planned`): the merged corrective reference doc at `docs/design/176-create-the-missing-concrete-benchmark-game-suite-spec-artifact.md`.\n\n## Scope\n- Add `docs/design/166-benchmarksgame-suite.md` by transcribing the reviewed contract from the merged issue #176 reference doc without widening scope beyond the already approved benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.\n- Keep this issue doc-only and artifact-focused: create the missing concrete suite-spec file and only the minimal doc cross-links strictly required for clarity. Do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n- Preserve the exact planned downstream path names and command-shape contract so later workers can rely on `docs/design/166-benchmarksgame-suite.md` alone instead of reconstructing intent from the issue #176 planning doc.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.\n- The doc stays materially aligned with the merged issue #176 reference doc and preserves the exact benchmark list, path names, validation rules, and comparison protocol it specifies.\n- The child issue lands only the missing concrete suite-spec doc artifact.",
+      "depends_on": [
+        {
+          "node_id": "suite_contract_artifact_v2",
+          "requires": "planned"
+        }
+      ],
+      "kind": "reference_doc",
+      "node_id": "suite_contract_artifact_v3",
+      "title": "Materialize the concrete benchmark game suite spec artifact on main"
     },
     {
       "body_markdown": "Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` so downstream implementation nodes have the exact contract file they are supposed to consume.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.\n\n## Scope\n- Author `docs/design/166-benchmarksgame-suite.md` from the merged design contract without widening scope beyond the already reviewed benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.\n- Keep this issue doc-only: add the concrete suite-spec artifact and any minimal doc cross-links needed for clarity, but do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n- Make the new suite-spec doc self-contained so later workers can rely on that exact file path instead of reconstructing intent from the higher-level design artifact.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.\n- The doc names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.\n- The child issue lands only the concrete suite-spec doc artifact.",
@@ -137,5 +149,5 @@
     }
   ],
   "roadmap_issue_number": 166,
-  "version": 3
+  "version": 4
 }

--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
@@ -7,20 +7,21 @@
 ## Metadata
 
 - Roadmap issue: `#166`
-- Graph version: `3`
-- Node count: `9`
+- Graph version: `4`
+- Node count: `10`
 
 ## Dependency Overview
 
 1. `suite_spec` (`reference_doc`): none
 2. `suite_contract_doc` (`reference_doc`): `suite_spec` (`planned`)
 3. `suite_contract_artifact_v2` (`reference_doc`): `suite_contract_doc` (`planned`)
-4. `bench_common_v3` (`small_job`): `suite_contract_artifact_v2` (`planned`)
-5. `bitmap_output_v3` (`small_job`): `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
-6. `numeric_kernels_v3` (`small_job`): `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
-7. `structural_kernels_v3` (`small_job`): `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
-8. `compare_harness_v3` (`small_job`): `bench_common_v3` (`implemented`), `bitmap_output_v3` (`implemented`), `numeric_kernels_v3` (`implemented`), `structural_kernels_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
-9. `docs_baseline_v3` (`small_job`): `compare_harness_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+4. `suite_contract_artifact_v3` (`reference_doc`): `suite_contract_artifact_v2` (`planned`)
+5. `bench_common_v4` (`small_job`): `suite_contract_artifact_v3` (`planned`)
+6. `bitmap_output_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+7. `numeric_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+8. `structural_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+9. `compare_harness_v4` (`small_job`): `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+10. `docs_baseline_v4` (`small_job`): `compare_harness_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 ## Nodes
 
@@ -91,18 +92,41 @@ Produce the missing concrete suite-spec artifact at `docs/design/166-benchmarksg
 - The doc stays materially aligned with the merged issue #173 reference doc and names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.
 - The child issue lands only the missing concrete suite-spec doc artifact.
 
-### `bench_common_v3`
+### `suite_contract_artifact_v3`
+
+- Kind: `reference_doc`
+- Title: Materialize the concrete benchmark game suite spec artifact on main
+- Depends on: `suite_contract_artifact_v2` (`planned`)
+
+#### Body
+
+Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` on the default branch so downstream implementation nodes can consume the promised contract file directly.
+
+## Direct Inputs
+- `suite_contract_artifact_v2` (`planned`): the merged corrective reference doc at `docs/design/176-create-the-missing-concrete-benchmark-game-suite-spec-artifact.md`.
+
+## Scope
+- Add `docs/design/166-benchmarksgame-suite.md` by transcribing the reviewed contract from the merged issue #176 reference doc without widening scope beyond the already approved benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.
+- Keep this issue doc-only and artifact-focused: create the missing concrete suite-spec file and only the minimal doc cross-links strictly required for clarity. Do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.
+- Preserve the exact planned downstream path names and command-shape contract so later workers can rely on `docs/design/166-benchmarksgame-suite.md` alone instead of reconstructing intent from the issue #176 planning doc.
+
+## Acceptance Criteria
+- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.
+- The doc stays materially aligned with the merged issue #176 reference doc and preserves the exact benchmark list, path names, validation rules, and comparison protocol it specifies.
+- The child issue lands only the missing concrete suite-spec doc artifact.
+
+### `bench_common_v4`
 
 - Kind: `small_job`
 - Title: Add shared benchmark game harness utilities
-- Depends on: `suite_contract_artifact_v2` (`planned`)
+- Depends on: `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Build the shared benchmark-game support layer that all benchmark implementations will use.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
 
 ## Scope
 - Add shared Bosatsu support under `src/Zafu/Benchmark/Game/` for command-line argument normalization, structured benchmark results, CSV row rendering, and reusable validation or output helpers required by the suite spec.
@@ -115,19 +139,19 @@ Build the shared benchmark-game support layer that all benchmark implementations
 - New common modules are fully exercised by repo tests and fit existing Bosatsu style.
 - `scripts/test.sh` passes.
 
-### `bitmap_output_v3`
+### `bitmap_output_v4`
 
 - Kind: `small_job`
 - Title: Implement the mandelbrot benchmark program
-- Depends on: `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+- Depends on: `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Implement `mandelbrot` with exact portable-bitmap output.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add a pure pixel and row-generation core plus a thin runnable `main` entrypoint under `src/Zafu/Benchmark/Game/`.
@@ -140,19 +164,19 @@ Implement `mandelbrot` with exact portable-bitmap output.
 - The executable runs on both Bosatsu JVM and C targets.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` passes.
 
-### `numeric_kernels_v3`
+### `numeric_kernels_v4`
 
 - Kind: `small_job`
 - Title: Implement n-body and spectral-norm benchmark programs
-- Depends on: `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+- Depends on: `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.
@@ -165,19 +189,19 @@ Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.
 - Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.
 
-### `structural_kernels_v3`
+### `structural_kernels_v4`
 
 - Kind: `small_job`
 - Title: Implement binary-trees and fannkuch-redux benchmark programs
-- Depends on: `bench_common_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+- Depends on: `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and `fannkuch-redux`.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common_v3` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.
 
 ## Scope
 - Add pure kernels plus thin runnable `main` entrypoints for `binary-trees` and `fannkuch-redux` under `src/Zafu/Benchmark/Game/`.
@@ -190,22 +214,22 @@ Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and 
 - Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.
 
-### `compare_harness_v3`
+### `compare_harness_v4`
 
 - Kind: `small_job`
 - Title: Vendor Java and C baselines and add the comparison runner
-- Depends on: `bench_common_v3` (`implemented`), `bitmap_output_v3` (`implemented`), `numeric_kernels_v3` (`implemented`), `structural_kernels_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+- Depends on: `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Vendor the comparison baselines and make local cross-language runs reproducible.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `bench_common_v3` (`implemented`): the shipped benchmark-game result schema and shared helpers.
-- `numeric_kernels_v3` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
-- `structural_kernels_v3` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
-- `bitmap_output_v3` (`implemented`): the shipped Bosatsu `mandelbrot` program.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.
+- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
+- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
+- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.
 
 ## Scope
 - Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.
@@ -218,19 +242,19 @@ Vendor the comparison baselines and make local cross-language runs reproducible.
 - Reference program provenance is explicit and reproducible.
 - Result normalization is tested, and the repo test suite remains green.
 
-### `docs_baseline_v3`
+### `docs_baseline_v4`
 
 - Kind: `small_job`
 - Title: Document the benchmark workflow and capture a first baseline
-- Depends on: `compare_harness_v3` (`implemented`), `suite_contract_artifact_v2` (`planned`)
+- Depends on: `compare_harness_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
 Document the workflow and check in a first reproducible local baseline.
 
 ## Direct Inputs
-- `suite_contract_artifact_v2` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `compare_harness_v3` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.
+- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `compare_harness_v4` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.
 
 ## Scope
 - Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.


### PR DESCRIPTION
Automated same-roadmap revision.

- target graph version: `4`
- roadmap doc path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md`
- graph path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json`
- summary: Pause the current ready frontier: `bench_common_v3` still expects `docs/design/166-benchmarksgame-suite.md`, but that concrete suite-spec artifact is not on `main`; the roadmap needs one corrective doc node and downstream re-pointing to that real artifact.

I reviewed `coding_style.md` and the current repo layout before evaluating the frontier. The implementation sequence itself still makes sense once the contract file exists: the repo has no `src/Zafu/Benchmark/Game/` tree yet, and the style guide still supports a harness-first split with explicit packages, pure helpers, paired tests, and `scripts/test.sh` as the gate.

The material problem is the current ready frontier. `bench_common_v3` is ready only because `suite_contract_artifact_v2` is marked completed, but its direct worker input is supposed to be the merged suite spec at `docs/design/166-benchmarksgame-suite.md`. That file is still absent on `main`; local inspection shows the merged upstream work produced `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`, `docs/design/173-author-the-concrete-benchmark-game-suite-spec-document.md`, and `docs/design/176-create-the-missing-concrete-benchmark-game-suite-spec-artifact.md`, with no `docs/design/166-benchmarksgame-suite.md` in the tree or history.

Because the completed upstream node did not actually materialize the promised artifact, issuing `bench_common_v3` now would force the worker to reconstruct the contract from planning docs and a mismatched dependency handoff. That violates the roadmap handoff contract: the ready worker should receive the exact direct artifact it is told to rely on, not infer it transitively or by repo search.

This is a same-roadmap correction, not a reason to abandon the effort. The revised graph adds a new corrective reference-doc node that actually creates `docs/design/166-benchmarksgame-suite.md` from the merged #176 planning doc, then replaces the unstarted pending implementation nodes with v4 equivalents that depend directly on that new artifact node. After that correction, the roadmap can continue with the same harness-first structure and the new ready frontier becomes the corrective doc-materialization node.

Refs #166