### PR TITLE
Roadmap revision for #166 (v5)

### DIFF
--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
@@ -29,7 +29,7 @@
       "title": "Implement the mandelbrot benchmark program"
     },
     {
-      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.\n- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.\n- Reference program provenance is explicit and reproducible.\n- Result normalization is tested, and the repo test suite remains green.",
+      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible with the corrected Bosatsu JVM command matrix.\n\n## Direct Inputs\n- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the corrected suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, benchmark arguments, and any target-specific launch caveats.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Implement the corrected Bosatsu JVM execution path required by the suite spec so binary benchmarks, especially `mandelbrot`, run with byte-exact stdout capture instead of the text-oriented `./bosatsu eval --run` contract. Text benchmarks may keep a lighter-weight JVM path only if the corrected suite spec says it remains valid.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, captured provenance, and the binary-output metadata required for `mandelbrot`.\n- Add smoke validation for the manifest, command-matrix expansion, and the byte-exact sample-validation path, and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine using the corrected per-target and per-benchmark command contract.\n- `mandelbrot` on `bosatsu_jvm` is validated through the byte-exact path recorded in the corrected suite spec rather than through a text-oriented eval invocation.\n- Reference program provenance is explicit and reproducible.\n- Result normalization and command-matrix logic are tested, and the repo test suite remains green.",
       "depends_on": [
         {
           "node_id": "bench_common_v4",
@@ -48,29 +48,29 @@
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v3",
+          "node_id": "suite_contract_artifact_v4",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "compare_harness_v4",
-      "title": "Vendor Java and C baselines and add the comparison runner"
+      "node_id": "compare_harness_v5",
+      "title": "Vendor Java and C baselines and add the corrected comparison runner"
     },
     {
-      "body_markdown": "Document the workflow and check in a first reproducible local baseline.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v4` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.\n- `scripts/test.sh` stays green.",
+      "body_markdown": "Document the workflow and check in a first reproducible local baseline using the corrected Bosatsu JVM benchmark contract.\n\n## Direct Inputs\n- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v5` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Document the corrected Bosatsu JVM command path clearly enough that another engineer can rerun both the text benchmarks and the byte-exact `mandelbrot` benchmark without reconstructing the launch rules from code.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used for each target.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine using the corrected command matrix.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite, including the byte-exact Bosatsu JVM path for `mandelbrot`.\n- `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "compare_harness_v4",
+          "node_id": "compare_harness_v5",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v3",
+          "node_id": "suite_contract_artifact_v4",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "docs_baseline_v4",
-      "title": "Document the benchmark workflow and capture a first baseline"
+      "node_id": "docs_baseline_v5",
+      "title": "Document the corrected benchmark workflow and capture a first baseline"
     },
     {
       "body_markdown": "Implement the numeric phase-1 benchmarks: `n-body` and `spectral-norm`.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped shared benchmark-game helpers from the common harness node.\n\n## Scope\n- Add pure kernel modules plus thin runnable `main` entrypoints for `n-body` and `spectral-norm` under `src/Zafu/Benchmark/Game/`.\n- Match the benchmarksgame algorithms, CLI shape, validation output, and large-N performance inputs recorded in the suite spec.\n- Prefer pure helpers for state stepping, matrix-vector math, formatting, and output verification so behavior is testable without shelling out.\n- Add exact sample-output tests for the official small-N validation cases, plus targeted tests for numerical invariants and formatting paths.\n\n## Acceptance Criteria\n- Both programs produce the expected benchmarksgame sample output.\n- Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.\n- Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.",
@@ -129,6 +129,18 @@
       "title": "Materialize the concrete benchmark game suite spec artifact on main"
     },
     {
+      "body_markdown": "Correct `docs/design/166-benchmarksgame-suite.md` so downstream workers no longer rely on the non-byte-exact `bosatsu_jvm` command shape for binary benchmarks.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n\n## Scope\n- Update `docs/design/166-benchmarksgame-suite.md` narrowly to distinguish the Bosatsu JVM command contract for text benchmarks from the byte-exact command contract required by binary-output benchmarks such as `mandelbrot`.\n- Record the exact local build or launch steps, stdout-capture expectations, and any per-benchmark command-matrix caveat needed so downstream workers can validate binary output without routing it through a text-oriented `./bosatsu eval --run` path.\n- Preserve the already approved phase-1 benchmark list, pinned Java and C sources, repository layout, result artifact schema, warmup and repeat policy, and all non-Bosatsu-JVM command contracts.\n- Keep this issue doc-only: do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` on the default branch states a byte-exact Bosatsu JVM contract for binary benchmarks and makes clear whether text benchmarks retain the existing `./bosatsu eval --run` path or use a different command shape.\n- Downstream workers can determine the exact `bosatsu_jvm` build and run commands for `mandelbrot` from the corrected doc alone, without guessing around stdout encoding behavior.\n- The change stays doc-only and materially preserves the rest of the approved suite contract.",
+      "depends_on": [
+        {
+          "node_id": "suite_contract_artifact_v3",
+          "requires": "planned"
+        }
+      ],
+      "kind": "reference_doc",
+      "node_id": "suite_contract_artifact_v4",
+      "title": "Correct the benchmark game suite spec for byte-exact Bosatsu JVM binary runs"
+    },
+    {
       "body_markdown": "Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` so downstream implementation nodes have the exact contract file they are supposed to consume.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.\n\n## Scope\n- Author `docs/design/166-benchmarksgame-suite.md` from the merged design contract without widening scope beyond the already reviewed benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.\n- Keep this issue doc-only: add the concrete suite-spec artifact and any minimal doc cross-links needed for clarity, but do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n- Make the new suite-spec doc self-contained so later workers can rely on that exact file path instead of reconstructing intent from the higher-level design artifact.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.\n- The doc names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.\n- The child issue lands only the concrete suite-spec doc artifact.",
       "depends_on": [
         {
@@ -149,5 +161,5 @@
     }
   ],
   "roadmap_issue_number": 166,
-  "version": 4
+  "version": 5
 }

--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
@@ -7,8 +7,8 @@
 ## Metadata
 
 - Roadmap issue: `#166`
-- Graph version: `4`
-- Node count: `10`
+- Graph version: `5`
+- Node count: `11`
 
 ## Dependency Overview
 
@@ -20,8 +20,9 @@
 6. `bitmap_output_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 7. `numeric_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 8. `structural_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
-9. `compare_harness_v4` (`small_job`): `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
-10. `docs_baseline_v4` (`small_job`): `compare_harness_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+9. `suite_contract_artifact_v4` (`reference_doc`): `suite_contract_artifact_v3` (`planned`)
+10. `compare_harness_v5` (`small_job`): `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v4` (`planned`)
+11. `docs_baseline_v5` (`small_job`): `compare_harness_v5` (`implemented`), `suite_contract_artifact_v4` (`planned`)
 
 ## Nodes
 
@@ -214,55 +215,82 @@ Implement the allocation and permutation phase-1 benchmarks: `binary-trees` and 
 - Both programs run through `./bosatsu eval --run` and `./bosatsu build` on the chosen entrypoints.
 - Changed Bosatsu modules reach the repo's 100% coverage target and `scripts/test.sh` stays green.
 
-### `compare_harness_v4`
+### `suite_contract_artifact_v4`
 
-- Kind: `small_job`
-- Title: Vendor Java and C baselines and add the comparison runner
-- Depends on: `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+- Kind: `reference_doc`
+- Title: Correct the benchmark game suite spec for byte-exact Bosatsu JVM binary runs
+- Depends on: `suite_contract_artifact_v3` (`planned`)
 
 #### Body
 
-Vendor the comparison baselines and make local cross-language runs reproducible.
+Correct `docs/design/166-benchmarksgame-suite.md` so downstream workers no longer rely on the non-byte-exact `bosatsu_jvm` command shape for binary benchmarks.
 
 ## Direct Inputs
 - `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+
+## Scope
+- Update `docs/design/166-benchmarksgame-suite.md` narrowly to distinguish the Bosatsu JVM command contract for text benchmarks from the byte-exact command contract required by binary-output benchmarks such as `mandelbrot`.
+- Record the exact local build or launch steps, stdout-capture expectations, and any per-benchmark command-matrix caveat needed so downstream workers can validate binary output without routing it through a text-oriented `./bosatsu eval --run` path.
+- Preserve the already approved phase-1 benchmark list, pinned Java and C sources, repository layout, result artifact schema, warmup and repeat policy, and all non-Bosatsu-JVM command contracts.
+- Keep this issue doc-only: do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.
+
+## Acceptance Criteria
+- `docs/design/166-benchmarksgame-suite.md` on the default branch states a byte-exact Bosatsu JVM contract for binary benchmarks and makes clear whether text benchmarks retain the existing `./bosatsu eval --run` path or use a different command shape.
+- Downstream workers can determine the exact `bosatsu_jvm` build and run commands for `mandelbrot` from the corrected doc alone, without guessing around stdout encoding behavior.
+- The change stays doc-only and materially preserves the rest of the approved suite contract.
+
+### `compare_harness_v5`
+
+- Kind: `small_job`
+- Title: Vendor Java and C baselines and add the corrected comparison runner
+- Depends on: `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v4` (`planned`)
+
+#### Body
+
+Vendor the comparison baselines and make local cross-language runs reproducible with the corrected Bosatsu JVM command matrix.
+
+## Direct Inputs
+- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
 - `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.
 - `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
 - `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
 - `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.
 
 ## Scope
-- Vendor the exact Java and C reference sources named in the suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, and benchmark arguments.
+- Vendor the exact Java and C reference sources named in the corrected suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, benchmark arguments, and any target-specific launch caveats.
 - Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.
-- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, and captured provenance.
-- Add smoke validation for the manifest or normalization layer and document all required local toolchain prerequisites.
+- Implement the corrected Bosatsu JVM execution path required by the suite spec so binary benchmarks, especially `mandelbrot`, run with byte-exact stdout capture instead of the text-oriented `./bosatsu eval --run` contract. Text benchmarks may keep a lighter-weight JVM path only if the corrected suite spec says it remains valid.
+- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, captured provenance, and the binary-output metadata required for `mandelbrot`.
+- Add smoke validation for the manifest, command-matrix expansion, and the byte-exact sample-validation path, and document all required local toolchain prerequisites.
 
 ## Acceptance Criteria
-- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine.
+- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine using the corrected per-target and per-benchmark command contract.
+- `mandelbrot` on `bosatsu_jvm` is validated through the byte-exact path recorded in the corrected suite spec rather than through a text-oriented eval invocation.
 - Reference program provenance is explicit and reproducible.
-- Result normalization is tested, and the repo test suite remains green.
+- Result normalization and command-matrix logic are tested, and the repo test suite remains green.
 
-### `docs_baseline_v4`
+### `docs_baseline_v5`
 
 - Kind: `small_job`
-- Title: Document the benchmark workflow and capture a first baseline
-- Depends on: `compare_harness_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
+- Title: Document the corrected benchmark workflow and capture a first baseline
+- Depends on: `compare_harness_v5` (`implemented`), `suite_contract_artifact_v4` (`planned`)
 
 #### Body
 
-Document the workflow and check in a first reproducible local baseline.
+Document the workflow and check in a first reproducible local baseline using the corrected Bosatsu JVM benchmark contract.
 
 ## Direct Inputs
-- `suite_contract_artifact_v3` (`planned`): the merged suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `compare_harness_v4` (`implemented`): the shipped comparison runner, vendored baselines, and normalized results format.
+- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `compare_harness_v5` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.
 
 ## Scope
 - Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.
-- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used.
+- Document the corrected Bosatsu JVM command path clearly enough that another engineer can rerun both the text benchmarks and the byte-exact `mandelbrot` benchmark without reconstructing the launch rules from code.
+- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used for each target.
 - Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.
 - Validate the documented commands once before merging.
 
 ## Acceptance Criteria
-- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine.
-- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite.
+- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine using the corrected command matrix.
+- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite, including the byte-exact Bosatsu JVM path for `mandelbrot`.
 - `scripts/test.sh` stays green.


### PR DESCRIPTION
Automated same-roadmap revision.

- target graph version: `5`
- roadmap doc path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md`
- graph path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json`
- summary: Keep the active roadmap and insert a corrective suite-spec doc plus replacement downstream nodes so binary benchmarks get a byte-exact Bosatsu JVM contract.

Revision is safer than abandonment because the defect is localized to the documented `bosatsu_jvm` command contract for binary-output benchmarks, not to the benchmark-suite goal itself. `suite_contract_artifact_v3` remains a completed artifact, but it currently routes all JVM runs through `./bosatsu eval --run`, which is not safe as the canonical byte-exact contract for `mandelbrot`.

Started nodes are preserved unchanged: `suite_spec`, `suite_contract_doc`, `suite_contract_artifact_v2`, `suite_contract_artifact_v3`, `bench_common_v4`, `bitmap_output_v4`, `numeric_kernels_v4`, and `structural_kernels_v4` already have completed or issued child issues, so this revision does not churn their identities or rewrite their worker handoffs.

Pending `compare_harness_v4` and `docs_baseline_v4` are retired and replaced. A new direct reference-doc dependency, `suite_contract_artifact_v4`, updates `docs/design/166-benchmarksgame-suite.md` with the corrected byte-exact Bosatsu JVM binary contract. `compare_harness_v5` now depends directly on that corrected artifact plus the shipped benchmark nodes, so its worker receives both the exact corrected contract and the concrete implemented inputs it must integrate. `docs_baseline_v5` depends directly on the corrected doc and the new harness node for the same reason.

This keeps the roadmap acyclic, preserves all started work, and makes the binary-output JVM correction explicit at the earliest artifact that downstream workers actually need.

Refs #166