### PR TITLE
Roadmap revision for #166 (v6)

### DIFF
--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json
@@ -29,7 +29,7 @@
       "title": "Implement the mandelbrot benchmark program"
     },
     {
-      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible with the corrected Bosatsu JVM command matrix.\n\n## Direct Inputs\n- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the corrected suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, benchmark arguments, and any target-specific launch caveats.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Implement the corrected Bosatsu JVM execution path required by the suite spec so binary benchmarks, especially `mandelbrot`, run with byte-exact stdout capture instead of the text-oriented `./bosatsu eval --run` contract. Text benchmarks may keep a lighter-weight JVM path only if the corrected suite spec says it remains valid.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, captured provenance, and the binary-output metadata required for `mandelbrot`.\n- Add smoke validation for the manifest, command-matrix expansion, and the byte-exact sample-validation path, and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine using the corrected per-target and per-benchmark command contract.\n- `mandelbrot` on `bosatsu_jvm` is validated through the byte-exact path recorded in the corrected suite spec rather than through a text-oriented eval invocation.\n- Reference program provenance is explicit and reproducible.\n- Result normalization and command-matrix logic are tested, and the repo test suite remains green.",
+      "body_markdown": "Vendor the comparison baselines and make local cross-language runs reproducible with the corrected Bosatsu JVM command matrix.\n\n## Direct Inputs\n- `suite_contract_artifact_v5` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.\n- `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.\n- `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.\n- `bitmap_output_v4` (`implemented`): the shipped Bosatsu `mandelbrot` program.\n\n## Scope\n- Vendor the exact Java and C reference sources named in the corrected suite spec under a checked-in directory, together with a small provenance manifest that records source URLs, date or commit identifiers, required compiler flags, benchmark arguments, and any target-specific launch caveats.\n- Add the local comparison runner, keeping shell logic declarative and minimal. Put command-matrix expansion, result normalization, and output shaping in testable repo code or data so the orchestration is reviewable and not a bag of ad hoc shell conditionals.\n- Implement the corrected Bosatsu JVM execution path required by the suite spec so binary benchmarks, especially `mandelbrot`, run with byte-exact stdout capture instead of the text-oriented `./bosatsu eval --run` contract. Text benchmarks may keep a lighter-weight JVM path only if the corrected suite spec says it remains valid.\n- Support Bosatsu JVM, Bosatsu C, Java, and C for the phase-1 benchmark set on a single machine, emitting normalized CSV or JSON with benchmark name, target, input, elapsed time, exit status, captured provenance, and the binary-output metadata required for `mandelbrot`.\n- Add smoke validation for the manifest, command-matrix expansion, and the byte-exact sample-validation path, and document all required local toolchain prerequisites.\n\n## Acceptance Criteria\n- A single checked-in command can build and run all Bosatsu, Java, and C baselines for the chosen suite on one machine using the corrected per-target and per-benchmark command contract.\n- `mandelbrot` on `bosatsu_jvm` is validated through the byte-exact path recorded in the corrected suite spec rather than through a text-oriented eval invocation.\n- Reference program provenance is explicit and reproducible.\n- Result normalization and command-matrix logic are tested, and the repo test suite remains green.",
       "depends_on": [
         {
           "node_id": "bench_common_v4",
@@ -48,28 +48,28 @@
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v4",
+          "node_id": "suite_contract_artifact_v5",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "compare_harness_v5",
+      "node_id": "compare_harness_v6",
       "title": "Vendor Java and C baselines and add the corrected comparison runner"
     },
     {
-      "body_markdown": "Document the workflow and check in a first reproducible local baseline using the corrected Bosatsu JVM benchmark contract.\n\n## Direct Inputs\n- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v5` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Document the corrected Bosatsu JVM command path clearly enough that another engineer can rerun both the text benchmarks and the byte-exact `mandelbrot` benchmark without reconstructing the launch rules from code.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used for each target.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine using the corrected command matrix.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite, including the byte-exact Bosatsu JVM path for `mandelbrot`.\n- `scripts/test.sh` stays green.",
+      "body_markdown": "Document the workflow and check in a first reproducible local baseline using the corrected Bosatsu JVM benchmark contract.\n\n## Direct Inputs\n- `suite_contract_artifact_v5` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.\n- `compare_harness_v6` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.\n\n## Scope\n- Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.\n- Document the corrected Bosatsu JVM command path clearly enough that another engineer can rerun both the text benchmarks and the byte-exact `mandelbrot` benchmark without reconstructing the launch rules from code.\n- Add a checked-in baseline artifact under `docs/benchmarksgame/` capturing one local run across Bosatsu JVM, Bosatsu C, Java, and C, including machine or toolchain metadata and the exact command used for each target.\n- Keep benchmark results informational only: do not add CI thresholds or fail builds on performance numbers.\n- Validate the documented commands once before merging.\n\n## Acceptance Criteria\n- README plus the docs artifact are enough for another engineer to rerun the same comparison on a comparable machine using the corrected command matrix.\n- The baseline results include provenance, benchmark inputs, and per-target measurements for the whole phase-1 suite, including the byte-exact Bosatsu JVM path for `mandelbrot`.\n- `scripts/test.sh` stays green.",
       "depends_on": [
         {
-          "node_id": "compare_harness_v5",
+          "node_id": "compare_harness_v6",
           "requires": "implemented"
         },
         {
-          "node_id": "suite_contract_artifact_v4",
+          "node_id": "suite_contract_artifact_v5",
           "requires": "planned"
         }
       ],
       "kind": "small_job",
-      "node_id": "docs_baseline_v5",
+      "node_id": "docs_baseline_v6",
       "title": "Document the corrected benchmark workflow and capture a first baseline"
     },
     {
@@ -141,6 +141,22 @@
       "title": "Correct the benchmark game suite spec for byte-exact Bosatsu JVM binary runs"
     },
     {
+      "body_markdown": "Apply the merged byte-exact Bosatsu JVM correction to `docs/design/166-benchmarksgame-suite.md` on the default branch so downstream implementation nodes can consume the corrected contract file directly.\n\n## Direct Inputs\n- `suite_contract_artifact_v3` (`planned`): the merged current suite spec artifact at `docs/design/166-benchmarksgame-suite.md`.\n- `suite_contract_artifact_v4` (`planned`): the merged correction design doc at `docs/design/190-correct-the-benchmark-game-suite-spec-for-byte-exact-bosatsu-jvm-binary-runs.md`.\n\n## Scope\n- Edit `docs/design/166-benchmarksgame-suite.md` by applying the merged issue #190 correction so the Bosatsu JVM contract explicitly separates the four text benchmarks from the byte-exact `mandelbrot` path.\n- Replace the current single `bosatsu_jvm` command template with the corrected per-output-mode contract, including the explicit JVM jar invocation for text benchmarks and the explicit byte-exact build and run path for `mandelbrot`.\n- Update the related output-handling language so the byte-exact stdout capture, temporary-file convention, and validation expectations are unambiguous for `mandelbrot`.\n- Preserve the approved phase-1 benchmark list, pinned Java and C sources, repository layout conventions, validation rules, warmup and repeat policy, metadata schema, and every non-Bosatsu-JVM target contract.\n- Keep this issue doc-only: do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` on the default branch reflects the merged issue #190 correction and no longer presents `bosatsu_jvm` as a single command template for all five benchmarks.\n- The corrected doc gives downstream workers enough information to determine the exact text-benchmark JVM command and the exact byte-exact `mandelbrot` JVM path from the artifact alone.\n- The change stays doc-only and materially preserves the rest of the approved suite contract.",
+      "depends_on": [
+        {
+          "node_id": "suite_contract_artifact_v3",
+          "requires": "planned"
+        },
+        {
+          "node_id": "suite_contract_artifact_v4",
+          "requires": "planned"
+        }
+      ],
+      "kind": "reference_doc",
+      "node_id": "suite_contract_artifact_v5",
+      "title": "Apply the byte-exact Bosatsu JVM suite-spec correction on main"
+    },
+    {
       "body_markdown": "Produce the concrete suite-spec artifact at `docs/design/166-benchmarksgame-suite.md` so downstream implementation nodes have the exact contract file they are supposed to consume.\n\n## Direct Inputs\n- `suite_spec` (`planned`): the merged design contract at `docs/design/168-write-the-benchmark-game-suite-spec-and-comparison-contract.md`.\n\n## Scope\n- Author `docs/design/166-benchmarksgame-suite.md` from the merged design contract without widening scope beyond the already reviewed benchmark matrix, deferred-benchmark rationale, pinned Java/C source pages, repo layout conventions, validation rules, and single-machine comparison protocol.\n- Keep this issue doc-only: add the concrete suite-spec artifact and any minimal doc cross-links needed for clarity, but do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.\n- Make the new suite-spec doc self-contained so later workers can rely on that exact file path instead of reconstructing intent from the higher-level design artifact.\n\n## Acceptance Criteria\n- `docs/design/166-benchmarksgame-suite.md` exists on the default branch and contains the full phase-1 benchmark contract needed by downstream implementation nodes.\n- The doc names the exact planned source, fixture, vendor, script, and results paths that later nodes will touch.\n- The child issue lands only the concrete suite-spec doc artifact.",
       "depends_on": [
         {
@@ -161,5 +177,5 @@
     }
   ],
   "roadmap_issue_number": 166,
-  "version": 5
+  "version": 6
 }

--- a/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
+++ b/docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md
@@ -7,8 +7,8 @@
 ## Metadata
 
 - Roadmap issue: `#166`
-- Graph version: `5`
-- Node count: `11`
+- Graph version: `6`
+- Node count: `12`
 
 ## Dependency Overview
 
@@ -21,8 +21,9 @@
 7. `numeric_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 8. `structural_kernels_v4` (`small_job`): `bench_common_v4` (`implemented`), `suite_contract_artifact_v3` (`planned`)
 9. `suite_contract_artifact_v4` (`reference_doc`): `suite_contract_artifact_v3` (`planned`)
-10. `compare_harness_v5` (`small_job`): `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v4` (`planned`)
-11. `docs_baseline_v5` (`small_job`): `compare_harness_v5` (`implemented`), `suite_contract_artifact_v4` (`planned`)
+10. `suite_contract_artifact_v5` (`reference_doc`): `suite_contract_artifact_v3` (`planned`), `suite_contract_artifact_v4` (`planned`)
+11. `compare_harness_v6` (`small_job`): `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v5` (`planned`)
+12. `docs_baseline_v6` (`small_job`): `compare_harness_v6` (`implemented`), `suite_contract_artifact_v5` (`planned`)
 
 ## Nodes
 
@@ -239,18 +240,44 @@ Correct `docs/design/166-benchmarksgame-suite.md` so downstream workers no longe
 - Downstream workers can determine the exact `bosatsu_jvm` build and run commands for `mandelbrot` from the corrected doc alone, without guessing around stdout encoding behavior.
 - The change stays doc-only and materially preserves the rest of the approved suite contract.
 
-### `compare_harness_v5`
+### `suite_contract_artifact_v5`
+
+- Kind: `reference_doc`
+- Title: Apply the byte-exact Bosatsu JVM suite-spec correction on main
+- Depends on: `suite_contract_artifact_v3` (`planned`), `suite_contract_artifact_v4` (`planned`)
+
+#### Body
+
+Apply the merged byte-exact Bosatsu JVM correction to `docs/design/166-benchmarksgame-suite.md` on the default branch so downstream implementation nodes can consume the corrected contract file directly.
+
+## Direct Inputs
+- `suite_contract_artifact_v3` (`planned`): the merged current suite spec artifact at `docs/design/166-benchmarksgame-suite.md`.
+- `suite_contract_artifact_v4` (`planned`): the merged correction design doc at `docs/design/190-correct-the-benchmark-game-suite-spec-for-byte-exact-bosatsu-jvm-binary-runs.md`.
+
+## Scope
+- Edit `docs/design/166-benchmarksgame-suite.md` by applying the merged issue #190 correction so the Bosatsu JVM contract explicitly separates the four text benchmarks from the byte-exact `mandelbrot` path.
+- Replace the current single `bosatsu_jvm` command template with the corrected per-output-mode contract, including the explicit JVM jar invocation for text benchmarks and the explicit byte-exact build and run path for `mandelbrot`.
+- Update the related output-handling language so the byte-exact stdout capture, temporary-file convention, and validation expectations are unambiguous for `mandelbrot`.
+- Preserve the approved phase-1 benchmark list, pinned Java and C sources, repository layout conventions, validation rules, warmup and repeat policy, metadata schema, and every non-Bosatsu-JVM target contract.
+- Keep this issue doc-only: do not touch `src/`, `fixtures/`, `vendor/`, `scripts/`, `README.md`, or benchmark result artifacts.
+
+## Acceptance Criteria
+- `docs/design/166-benchmarksgame-suite.md` on the default branch reflects the merged issue #190 correction and no longer presents `bosatsu_jvm` as a single command template for all five benchmarks.
+- The corrected doc gives downstream workers enough information to determine the exact text-benchmark JVM command and the exact byte-exact `mandelbrot` JVM path from the artifact alone.
+- The change stays doc-only and materially preserves the rest of the approved suite contract.
+
+### `compare_harness_v6`
 
 - Kind: `small_job`
 - Title: Vendor Java and C baselines and add the corrected comparison runner
-- Depends on: `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v4` (`planned`)
+- Depends on: `bench_common_v4` (`implemented`), `bitmap_output_v4` (`implemented`), `numeric_kernels_v4` (`implemented`), `structural_kernels_v4` (`implemented`), `suite_contract_artifact_v5` (`planned`)
 
 #### Body
 
 Vendor the comparison baselines and make local cross-language runs reproducible with the corrected Bosatsu JVM command matrix.
 
 ## Direct Inputs
-- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `suite_contract_artifact_v5` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
 - `bench_common_v4` (`implemented`): the shipped benchmark-game result schema and shared helpers.
 - `numeric_kernels_v4` (`implemented`): the shipped Bosatsu `n-body` and `spectral-norm` programs.
 - `structural_kernels_v4` (`implemented`): the shipped Bosatsu `binary-trees` and `fannkuch-redux` programs.
@@ -269,19 +296,19 @@ Vendor the comparison baselines and make local cross-language runs reproducible 
 - Reference program provenance is explicit and reproducible.
 - Result normalization and command-matrix logic are tested, and the repo test suite remains green.
 
-### `docs_baseline_v5`
+### `docs_baseline_v6`
 
 - Kind: `small_job`
 - Title: Document the corrected benchmark workflow and capture a first baseline
-- Depends on: `compare_harness_v5` (`implemented`), `suite_contract_artifact_v4` (`planned`)
+- Depends on: `compare_harness_v6` (`implemented`), `suite_contract_artifact_v5` (`planned`)
 
 #### Body
 
 Document the workflow and check in a first reproducible local baseline using the corrected Bosatsu JVM benchmark contract.
 
 ## Direct Inputs
-- `suite_contract_artifact_v4` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
-- `compare_harness_v5` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.
+- `suite_contract_artifact_v5` (`planned`): the merged corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`.
+- `compare_harness_v6` (`implemented`): the shipped comparison runner, vendored baselines, normalized results format, and corrected Bosatsu JVM command matrix.
 
 ## Scope
 - Update `README.md` with how to fetch prerequisites, build the Bosatsu benchmark-game programs, run the comparison harness, and interpret the emitted results without over-claiming benchmarksgame significance.


### PR DESCRIPTION
Automated same-roadmap revision.

- target graph version: `6`
- roadmap doc path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.md`
- graph path: `docs/roadmap/166-implement-solutions-and-benchmarks-for-computer-benchmarks-game.graph.json`
- summary: Revise before issuing more child work: `compare_harness_v5` is only nominally ready because its `suite_contract_artifact_v4` handoff produced the design doc for the correction, not a corrected `docs/design/166-benchmarksgame-suite.md` artifact on `main`.

The ready frontier is `compare_harness_v5`, and every one of its declared dependencies is marked satisfied. The problem is that the direct dependency handoff for `suite_contract_artifact_v4` is materially wrong for what that frontier worker needs on turn one. The completed child work for `suite_contract_artifact_v4` merged `docs/design/190-correct-the-benchmark-game-suite-spec-for-byte-exact-bosatsu-jvm-binary-runs.md`, while `docs/design/166-benchmarksgame-suite.md` on `main` still carries the old universal `bosatsu_jvm` command template `./bosatsu eval --main Zafu/Benchmark/Game/<Package>::main --run <N>`. That means the current frontier would be handed a design artifact plus an uncorrected suite contract, even though its node body says it can rely directly on a corrected suite spec doc at `docs/design/166-benchmarksgame-suite.md`. Under the roadmap handoff contract, that is not enough: the worker would have to reconstruct the intended correction from the design doc or repo history instead of receiving the concrete corrected artifact directly.

The smallest same-roadmap repair is to keep all started nodes unchanged, retain `suite_contract_artifact_v4` as the completed correction design input, add a new reference-doc node that actually applies that correction onto `docs/design/166-benchmarksgame-suite.md`, and then retarget the pending comparison and baseline nodes to that new concrete artifact. The new doc node depends directly on both `suite_contract_artifact_v3` (`planned`) and `suite_contract_artifact_v4` (`planned`) so its worker receives both the current suite-spec artifact to edit and the merged design doc that describes the correction. `compare_harness_v5` and `docs_baseline_v5` are still unstarted, so they can be retired and replaced with `compare_harness_v6` and `docs_baseline_v6` that depend on the new corrected suite-spec artifact instead of the design-doc node. After that repair, the frontier becomes sound again because the comparison-runner worker will receive the exact corrected contract file it is supposed to implement against.

Refs #166