### PR TITLE
Design doc for #207: Design: migrate Hash typeclass to use Int64 not Int

### DIFF
--- a/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+++ b/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
@@ -15,7 +15,7 @@ touch_paths:
   - src/Zafu/Collection/NonEmptyChain.bosatsu
 depends_on: []
 estimated_size: M
-generated_at: 2026-04-09T23:05:42Z
+generated_at: 2026-04-18T18:22:35Z
 ---
 
 # Design: migrate Hash typeclass to use Int64 not Int
@@ -24,16 +24,19 @@ _Issue: #207 (https://github.com/johnynek/zafu/issues/207)_
 
 ## Summary
 
-Plan the Int64 migration of `Hash`, move HAMT cached hashes and bitmaps onto `Int64`, and validate the change with stronger invariants plus property-driven tests.
-
-## Status
-Planned. Merging this design doc is the planned milestone for issue #207; implementation may continue afterward on the same child issue.
+Plan the Hash Int64 migration, move HashMap and HashSet hot-path internals onto Int64, and validate the change with stronger invariant-driven tests.
 
 ## Context
-`Zafu/Abstract/Hash` currently stores `hash_fn: a -> Int`, and the exported helper pipeline in `Hash`, `Predef`, `HashMap`, and `HashSet` assumes `Int`-typed hashes.
-`HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, collision hashes, HAMT bitmaps, fragment helpers, and unordered collection-hash accumulators are still `Int`.
-Issue #207 asks for two related changes: move the `Hash` typeclass itself to `Int64`, and audit `HashMap` and `HashSet` so the hot path uses fixed-width integer operations wherever Bosatsu's `Int64` API makes that practical.
-The current design also relies on a canonical non-negative 61-bit hash domain, and HAMT navigation assumes those hashes can be fragmented predictably in 5-bit chunks.
+`Zafu/Abstract/Hash` currently stores `hash_fn: a -> Int`, and the public helpers in `Hash`, `Predef`, `HashMap`, `HashSet`, and downstream adapters assume `Int`-typed hashes.
+`HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, collision hashes, HAMT bitmaps, and unordered collection-hash accumulators still use `Int`.
+Issue #207 asks for two related changes: move the `Hash` typeclass itself to `Int64`, and audit `HashMap` and `HashSet` so the hot path uses `Int64` wherever the Bosatsu `Int64` API makes that practical.
+The Bosatsu `Int64` docs provide the operations needed for this sweep: arithmetic and bitwise operators, `mod_Int64`, `popcount_Int64`, `shift_right_unsigned_Int64`, and explicit conversions such as `int_to_Int64` and `int_low_bits_to_Int64`.
+Merging this design doc is the planned milestone for this lane. Implementation may continue afterward on the same child issue.
+
+## Problem
+The current design pays repeated `Int` and `Int64` conversion costs in the most hash-heavy code paths.
+That split also hides important invariants. `HashMap` and `HashSet` currently validate cached size in tests, but they do not check cached-hash correctness, bitmap shape, collision-node consistency, or canonical hash range.
+A type-only migration would not be enough. If `Hash[a]` changes to `Int64` while HAMT internals and collection hash adapters keep widening back to `Int`, the repo absorbs the churn without getting the intended simplification or performance benefit.
 
 ## Goals
 1. Change `Hash[a]` so the stored hash function and `hash(inst, value)` return `Int64`.
@@ -45,48 +48,51 @@ The current design also relies on a canonical non-negative 61-bit hash domain, a
 
 ## Non-goals
 1. Changing public collection sizes or other user-facing count APIs from `Int` to `Int64`.
-2. Introducing a dual API where both `Hash[a] -> Int` and `Hash[a] -> Int64` remain supported long term.
+2. Keeping a long-term dual public hash result API where both `Int` and `Int64` are primary results.
 3. Redesigning unrelated collection algorithms outside hash-related hot paths.
-4. Promising that every concrete numeric hash output remains part of the public contract, even if the implementation target preserves current 61-bit behavior.
+4. Promising that every concrete numeric hash output is part of the public contract beyond the existing coherence and domain guarantees.
 5. Introducing cryptographic hashing or stronger collision-resistance guarantees.
 
-## Architecture
+## Proposed Design
 
 ### Hash Core API
 1. Change `src/Zafu/Abstract/Hash.bosatsu` to `struct Hash[a](hash_fn: a -> Int64, eq_inst: Eq[a])` and make `hash(inst, value) -> Int64`.
-2. Keep `hash_specialized` as the fast constructor for already-canonical `Int64` hash functions.
-3. Keep an Int-projection adapter so simple instances such as `hash_Int` and `hash_Char` do not need repetitive conversion boilerplate. The intended shape is to normalize in `Int`, then narrow only after the value is known to fit in the 61-bit canonical domain.
-4. Keep `mix_61` and `finish_61` as the main exported composition helpers, but make their working representation `Int64`.
-5. Continue accepting tuple arity and collection size inputs as `Int` at the public boundary. `finish_61` should reduce or bound-check those counts before converting them into the canonical `Int64` domain so the migration does not rely on silent truncation.
+2. Make `hash_specialized` the Int64-native constructor for already-canonical hash functions.
+3. Retain a compatibility constructor for simple `Int`-producing code paths. The intended shape is to keep `hash_from_fn` as the adapter that normalizes an `a -> Int` into the canonical `Int64` domain, so existing simple instances do not gain repetitive conversion boilerplate.
+4. Keep `mix_61` and `finish_61` as the main exported composition helpers, but move their working representation to `Int64`.
+5. Keep tuple arity and collection size inputs as `Int` at the public boundary. `finish_61` should convert those counts only after an explicit fit check or reduction into the canonical domain so the migration never relies on silent truncation.
+6. Keep `hash_to_Eq`, `hash_by`, and `laws_Hash`, updating their comparisons and range checks to `Int64`.
 
 ### 61-bit Int64 Arithmetic
-1. Keep the existing modulus `M = 2^61 - 1` and the existing domain-separation strategy of seeds and tags. Those constants should move to `Int64` so downstream hash builders stay in one numeric representation.
-2. Implement an internal `reduce_61_i64` helper for canonical `Int64` values using the Mersenne identity `2^61 ≡ 1 (mod M)`. For bounded non-negative intermediates, one or two fold-and-subtract passes are enough to return to `[0, M)`.
-3. Implement the hot multiplication step without widening the whole path back to `Int`. The recommended approach is a 31-bit/30-bit limb split for operands below `2^61`, so `mul_mod_61_i64(acc, mix_prime)` can be computed with bounded `Int64` intermediates and then reduced with `reduce_61_i64`.
-4. `mix_61(acc, next)` should therefore stay Int64-first: multiply in the 61-bit domain, add `next` and the fixed additive constant, then reduce back into the canonical range.
-5. `normalize_61` should remain available as the compatibility adapter for arbitrary `Int` inputs, but Hash internals, HAMT internals, and collection accumulators should prefer the Int64-native reduction helpers.
+1. Keep the existing modulus `M = 2^61 - 1` and the existing seed and tag domain-separation strategy. Move those constants to `Int64` so downstream hash builders stay in one representation.
+2. Preserve the canonical exported invariant that every public hash lies in `[0, M)`.
+3. Implement an internal `reduce_61_i64` helper using the Mersenne identity `2^61 ≡ 1 (mod M)`. For bounded non-negative intermediates, fold high bits back into the low 61 bits and subtract `M` when needed.
+4. Implement a dedicated multiply-reduce helper for `mix_61` that stays Int64-first. It should use `Int64` limb decomposition and reduction rather than widening the hot path back to arbitrary-precision `Int`.
+5. Keep `normalize_61` as the compatibility adapter for arbitrary `Int` inputs, but Hash internals and collection internals should prefer Int64-native reduction helpers once data is in the canonical domain.
+6. Validate the Int64 arithmetic against a clearer `Int`-based oracle in tests so the subtle math stays explainable and checkable.
 
 ### HashMap and HashSet Internals
 1. In `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, change cached `Entry.hash` and `Collision.hash` from `Int` to `Int64`.
-2. Change `Indexed.data_bitmap` and `Indexed.node_bitmap` from `Int` to `Int64`. Only the low 32 bits are semantically used, but representing them as `Int64` avoids bouncing between `Int` and `Int64` on the same hot path.
+2. Change `Indexed.data_bitmap` and `Indexed.node_bitmap` from `Int` to `Int64`. Only the low 32 bits are semantically used, but representing them as `Int64` avoids bouncing between numeric types on the same path.
 3. Keep public `size`, loop fuel, and shift counts as `Int`. The intended split is: payload hashes and bitmaps are `Int64`; public counts remain `Int`.
-4. Rework helpers such as `fragment`, `bitpos`, `has_bit`, and `bitmap_index` around `Int64` bitwise operations, `popcount_Int64`, and unsigned right shift where fragment extraction would otherwise depend on sign behavior.
-5. Keep map and set hash adapters order-independent. The current `sum_acc` plus `xor_acc` strategy can remain, but the accumulators and XOR path should become `Int64` so equal maps or sets hash equally regardless of insertion order.
-6. Strengthen the test-only invariant helpers so they validate more than cached size: cached-hash correctness, collision-node consistency, bitmap disjointness, bitmap/popcount alignment, canonical range, and exact root size.
+4. Rework helpers such as `fragment`, `bitpos`, `has_bit`, and `bitmap_index` around `Int64` bitwise operations, `popcount_Int64`, and `shift_right_unsigned_Int64` where sign-sensitive right shift would otherwise be fragile.
+5. Keep map and set hash adapters order-insensitive. The current `sum_acc` plus `xor_acc` strategy can stay, but the accumulators and XOR path should become `Int64` so equal maps or sets hash equally regardless of insertion order.
+6. Strengthen the test-only invariant helpers so they validate more than cached size: cached-hash correctness, collision-node consistency, bitmap disjointness, bitmap and popcount alignment, canonical range, and exact root size.
 
 ### Wider Call-Site Sweep
-1. `src/Zafu/Abstract/Instances/Predef.bosatsu` is the largest direct migration surface. Primitive hashes, string/list hashing, option hashing, tuple hashing, and dict hashing all need Int64-backed helpers and constants.
-2. `src/Zafu/Collection/Vector.bosatsu` has explicit hash accumulators and a parity property against list hashing; it needs a direct migration to Int64-backed composition.
+1. `src/Zafu/Abstract/Instances/Predef.bosatsu` is the largest direct migration surface. Primitive hashes, string and list hashing, option hashing, tuple hashing, and dict hashing all need Int64-backed helpers and constants.
+2. `src/Zafu/Collection/Vector.bosatsu` has explicit hash accumulators and a parity property against list hashing. It needs a direct migration to Int64-backed composition.
 3. `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu` each define local constructor-tagged hash builders and currently assume `Int`-typed helper outputs.
-4. Inline tests in modules that compare hashes with `eq_Int` or `.eq_Int` must be updated to use `Int64`-appropriate comparisons. The likely touch points include `NonEmptyList` and `NonEmptyChain`, even though their hash implementations are adapter-only.
+4. Inline tests in `src/Zafu/Collection/NonEmptyList.bosatsu` and `src/Zafu/Collection/NonEmptyChain.bosatsu` compare hash results with `eq_Int`; those checks need to move to the Int64 equivalents.
+5. The migration should search explicitly for `hash_from_fn`, `hash_specialized`, `mix_61`, `finish_61`, `.eq_Int` on hash values, and `eq_Int(hash_Hash(...), ...)` so fallout is handled deliberately instead of reactively.
 
 ## Behavioral Properties and Invariants
 1. Eq/Hash coherence remains mandatory: if `eq(x, y)` holds, then `hash(x) == hash(y)` must also hold.
 2. Every exported hash value remains in `[0, 2^61 - 1)`.
-3. Hash results remain deterministic across supported backends because the implementation is defined in terms of Bosatsu's `Int64` operations and explicit reductions, not host-sized integer behavior.
+3. Hash results remain deterministic across supported backends because the implementation is defined in terms of Bosatsu `Int64` operations and explicit reductions, not host-sized integer behavior.
 4. Sequence-like structures remain order-sensitive. That includes lists, vectors, tuples, and constructor-tagged sum types.
 5. Unordered collection adapters remain order-insensitive. Equal `HashMap` and `HashSet` values must hash equally regardless of insertion order or traversal order.
-6. `HashMap` and `HashSet` public semantics do not change. Lookup, membership, update, alter, remove, transform, union, intersection, and difference must keep the same logical behavior as before.
+6. `HashMap` and `HashSet` public semantics do not change. Lookup, membership, update, alter, remove, transform, union, intersection, and difference keep the same logical behavior as before.
 7. Every cached HAMT entry hash equals a fresh recomputation from the stored `Hash[k]` dictionary and the stored key.
 8. Collision nodes contain only entries that share the collision hash, and they never persist as empty or single-entry nodes after compression.
 9. Indexed-node invariants remain strict: `data_bitmap & node_bitmap == 0`, `entries.size == popcount(data_bitmap)`, and `children.size == popcount(node_bitmap)`.
@@ -96,15 +102,15 @@ The current design also relies on a canonical non-negative 61-bit hash domain, a
 ## Implementation Plan
 1. Migrate `src/Zafu/Abstract/Hash.bosatsu` first. Change the core type signatures, add the Int64 reduction and multiply-reduce helpers, and keep a simple reference implementation in tests so the new arithmetic can be checked against a clearer oracle.
 2. Sweep `src/Zafu/Abstract/Instances/Predef.bosatsu` next. This updates the broadest surface area and unblocks downstream modules that depend on predef hash instances.
-3. Migrate `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu` together. Their HAMT representations and test models are intentionally parallel, so cached-hash and bitmap changes should stay structurally aligned.
-4. Update the remaining direct hash producers and consumers in `src/Zafu/Collection/Vector.bosatsu`, `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu`.
-5. Finish with the smaller inline-test fallout where modules compare hash values with `Int`-specific helpers.
+3. Migrate `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu` together. Their HAMT representations and property suites are intentionally parallel, so cached-hash and bitmap changes should stay structurally aligned.
+4. Update the remaining direct hash producers and consumers in `src/Zafu/Collection/Vector.bosatsu`, `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, `src/Zafu/Text/Parse/Error.bosatsu`, `src/Zafu/Collection/NonEmptyList.bosatsu`, and `src/Zafu/Collection/NonEmptyChain.bosatsu`.
+5. Run the repo-wide search for Int-specific hash comparisons and conversion leftovers before considering the migration complete.
 6. Validate only once the full repo-wide type migration is in place. A half-converted branch is not a useful intermediate state because `Hash[a]` sits at the center of many modules.
 
-## Test Plan
+## Test Strategy
 
 ### Property-Check Coverage
-1. Add randomized properties in `src/Zafu/Abstract/Hash.bosatsu` for the new Int64 arithmetic helpers. The key checks are canonical range preservation, reduction idempotence, and agreement with a simple reference implementation for randomly generated canonical inputs.
+1. Add randomized properties in `src/Zafu/Abstract/Hash.bosatsu` for the new Int64 arithmetic helpers. The key checks are canonical range preservation, reduction idempotence, and agreement with a simpler `Int`-based oracle for randomly generated canonical inputs.
 2. Keep or expand the hash-law checks in `src/Zafu/Abstract/Instances/Predef.bosatsu` so randomized coverage continues to assert Eq/Hash coherence, canonical range, constructor tagging, and sequence order sensitivity for common composite instances.
 3. Keep the model-based randomized operation tests in `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, but make every step also assert the strengthened HAMT invariants. Those properties are the right place to catch bugs introduced by cached-hash and bitmap type changes.
 4. Add permutation-style properties for map and set hash adapters so collections built from different insertion orders still hash equally.
@@ -113,7 +119,7 @@ The current design also relies on a canonical non-negative 61-bit hash domain, a
 ### Narrow Case Coverage
 1. Keep explicit `Float64` regressions for NaN canonicalization and signed zero. Those are small, sharp semantic cases where a named example is more valuable than a broad generator.
 2. Add boundary tests for normalization and fragment extraction around `-1`, `0`, `2^61 - 2`, `2^61 - 1`, and the fragment-shift boundaries `0`, `5`, and `60`.
-3. Keep direct collision-node insert/remove/compression tests in `HashMap` and `HashSet`. Randomized model tests are good at finding semantic drift, but node-collapse edge cases are still best pinned as named regressions.
+3. Keep direct collision-node insert, remove, and compression tests in `HashMap` and `HashSet`. Randomized model tests are good at finding semantic drift, but node-collapse edge cases are still best pinned as named regressions.
 4. Keep explicit cross-dictionary bulk-operation tests where left and right collections use different hash dictionaries. Those examples pin the intended fallback behavior more clearly than a generator alone.
 5. Keep constructor-tagging checks in `Result`, `PartialResult`, and `Text/Parse/Error` so refactors do not accidentally collapse distinct variants into the same hash domain.
 
@@ -126,13 +132,13 @@ The current design also relies on a canonical non-negative 61-bit hash domain, a
 6. `HashMap` and `HashSet` store cached hashes and HAMT bitmaps as `Int64`, while preserving existing public behavior.
 7. Strengthened HAMT invariants validate cached-hash correctness, collision-node consistency, bitmap alignment, bitmap disjointness, canonical range, and exact cached size.
 8. Property tests continue to pass for default, collision-heavy, and differing-hash-dictionary scenarios in `HashMap` and `HashSet`, and the `Vector` hash parity property still holds.
-9. Case-based tests cover `Float64` special cases, 61-bit boundary normalization, constructor tagging, and named collision/compression regressions.
+9. Case-based tests cover `Float64` special cases, 61-bit boundary normalization, constructor tagging, and named collision and compression regressions.
 10. `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` pass on the full migration branch.
 
 ## Risks and Rollout Notes
-1. Risk: the Int64 multiply-reduce helper is subtle and easy to get wrong. Mitigation: isolate it in `Hash`, validate it against a simpler reference implementation, and add targeted boundary tests in addition to random coverage.
-2. Risk: mixed `Int` and `Int64` conversions in HAMT code reintroduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and search specifically for `eq_Int`, `.eq_Int`, `hash_from_fn`, `hash_specialized`, `mix_61`, and `finish_61` call sites during the sweep.
+1. Risk: the Int64 multiply-reduce helper is subtle and easy to get wrong. Mitigation: isolate it in `Hash`, validate it against a simpler `Int`-based oracle, and add targeted boundary tests in addition to randomized coverage.
+2. Risk: mixed `Int` and `Int64` conversions in HAMT code reintroduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and search specifically for Int-specific hash comparisons and leftover narrowing paths during the sweep.
 3. Risk: the migration achieves the public type change but leaves performance on the table if hot loops still widen back to `Int`. Mitigation: keep cached hashes, bitmaps, fragment helpers, and unordered collection-hash accumulators Int64-first, and treat any remaining `Int` arithmetic as a deliberate boundary or compatibility path.
-4. Risk: downstream callers or inline tests depend on the old raw hash type. Mitigation: land the code change atomically, preserve an Int-projection constructor path, and update tests to talk about coherence and invariants rather than `Int`-specific helper APIs.
+4. Risk: downstream callers or inline tests depend on the old raw hash type. Mitigation: land the code change atomically, preserve a supported Int-adapter constructor path, and update tests to talk about coherence and invariants rather than `Int`-specific helper APIs.
 5. The design doc merge is the planned milestone for this lane. Implementation can continue afterward from the same child issue without reopening design.
-6. The code rollout should stay compile-green from `main`. If the implementation is split, each step still needs to leave the repo building; there is no useful long-lived mixed `Int`/`Int64` state for `Hash`.
+6. The implementation branch should stay close to `main` while this migration is in flight, because there is no useful long-lived mixed `Int` and `Int64` state for `Hash`.

--- a/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+++ b/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
@@ -15,7 +15,7 @@ touch_paths:
   - src/Zafu/Collection/NonEmptyChain.bosatsu
 depends_on: []
 estimated_size: M
-generated_at: 2026-04-18T18:22:35Z
+generated_at: 2026-04-18T21:33:22Z
 ---
 
 # Design: migrate Hash typeclass to use Int64 not Int
@@ -30,7 +30,7 @@ Plan the Hash Int64 migration, move HashMap and HashSet hot-path internals onto 
 `Zafu/Abstract/Hash` currently stores `hash_fn: a -> Int`, and the public helpers in `Hash`, `Predef`, `HashMap`, `HashSet`, and downstream adapters assume `Int`-typed hashes.
 `HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, collision hashes, HAMT bitmaps, and unordered collection-hash accumulators still use `Int`.
 Issue #207 asks for two related changes: move the `Hash` typeclass itself to `Int64`, and audit `HashMap` and `HashSet` so the hot path uses `Int64` wherever the Bosatsu `Int64` API makes that practical.
-The Bosatsu `Int64` docs provide the operations needed for this sweep: arithmetic and bitwise operators, `mod_Int64`, `popcount_Int64`, `shift_right_unsigned_Int64`, and explicit conversions such as `int_to_Int64` and `int_low_bits_to_Int64`.
+The [Bosatsu Int64 docs](https://johnynek.github.io/bosatsu/generated/core_alpha/Bosatsu/Num/Int64.html) provide the operations needed for this sweep: arithmetic and bitwise operators, `mod_Int64`, `popcount_Int64`, `shift_right_unsigned_Int64`, and explicit conversions such as `int_to_Int64` and `int_low_bits_to_Int64`.
 Merging this design doc is the planned milestone for this lane. Implementation may continue afterward on the same child issue.
 
 ## Problem

--- a/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+++ b/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
@@ -1,0 +1,131 @@
+---
+issue: 207
+priority: 3
+touch_paths:
+  - docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+  - src/Zafu/Abstract/Hash.bosatsu
+  - src/Zafu/Abstract/Instances/Predef.bosatsu
+  - src/Zafu/Collection/HashMap.bosatsu
+  - src/Zafu/Collection/HashSet.bosatsu
+  - src/Zafu/Collection/Vector.bosatsu
+  - src/Zafu/Control/Result.bosatsu
+  - src/Zafu/Control/PartialResult.bosatsu
+  - src/Zafu/Text/Parse/Error.bosatsu
+depends_on: []
+estimated_size: M
+generated_at: 2026-04-09T22:48:40Z
+---
+
+# Design: migrate Hash typeclass to use Int64 not Int
+
+_Issue: #207 (https://github.com/johnynek/zafu/issues/207)_
+
+## Summary
+
+Migrate `Hash` to `Int64` while keeping canonical 61-bit hashes, moving `HashMap` and `HashSet` hot-path hashing and bitmap math onto `Int64`, and validating the change with stronger invariant- and property-driven coverage.
+
+## Status
+Planned. Merging this doc is the planned milestone for issue #207; implementation can continue on the same child issue afterward.
+
+## Context
+`Zafu/Abstract/Hash` currently models `Hash[a]` as an `a -> Int` dictionary, and the exported helpers in `Hash`, `Predef`, `HashMap`, and `HashSet` all assume `Int`-typed hash values.
+`HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, node bitmaps, and collection-hash accumulators are still `Int`. That keeps the hottest hash-table paths on unbounded integers even though Bosatsu exposes a dedicated `Int64` API.
+Issue #207 asks for a repo-wide migration of the Hash typeclass to `Int64`, plus an audit of `HashMap` and `HashSet` so their internal hashing work uses `Int64` wherever it is actually on the hot path.
+
+## Goals
+1. Make `Hash[a]` produce `Int64` rather than `Int`.
+2. Preserve Eq/Hash coherence and deterministic non-cryptographic hashing semantics.
+3. Keep a canonical non-negative 61-bit hash domain so HAMT fragmenting stays stable and sign handling remains simple.
+4. Move `HashMap` and `HashSet` cached hashes, bitmap math, and collection-hash accumulators to `Int64`.
+5. Update in-repo hash producers and consumers with explicit `Int` hash annotations so the repo compiles cleanly after the type change.
+6. Strengthen invariant-driven tests so the migration is validated by behavior, not just by type-checking.
+
+## Non-goals
+1. Changing public collection sizes or user-facing count APIs from `Int` to `Int64`.
+2. Preserving exact numeric hash outputs across the migration. Behavioral properties matter; specific hash codes do not.
+3. Introducing cryptographic hashing or stronger collision-resistance guarantees.
+4. Reworking unrelated collection algorithms outside of hash-related hot paths.
+5. Carrying a compatibility mode where both `Hash[a] -> Int` and `Hash[a] -> Int64` coexist.
+
+## Architecture
+
+### Hash Core
+1. Change `Zafu/Abstract/Hash.bosatsu` so the stored hash function and `hash(inst, value)` both use `Int64`.
+2. Keep the public canonical hash range as `[0, 2^61 - 1)`. This preserves the current invariant that exported hashes are non-negative and leave the sign bit clear.
+3. Keep `hash_specialized` as the fast constructor for already-canonical `Int64` hash functions.
+4. Keep an adapter constructor for simple `Int` projections so instances like `hash_Int` and `hash_Char` do not need repetitive conversion boilerplate. That adapter should normalize in `Int`, then narrow only after the value is known to fit in the canonical 61-bit domain.
+5. Migrate `normalize_61`, `mix_61`, and `finish_61` to Int64-backed helpers. Their hot path should use Bosatsu `Int64` operations only; any wider `Int` arithmetic should be limited to compatibility adapters or reference tests.
+6. Keep domain separation via seeds and tags, but store those constants as `Int64` so downstream hash builders never widen just to mix constructor or collection tags.
+7. `finish_61` should continue accepting collection sizes and tuple arities from public `Int` APIs, but it should reduce those counts into the 61-bit domain before narrowing to `Int64`. That avoids silent truncation while keeping public size APIs unchanged.
+
+### HashMap and HashSet
+1. In `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, change cached `Entry.hash` and `Collision.hash` fields from `Int` to `Int64`.
+2. Change HAMT bitmaps from `Int` to `Int64` as well. Only the low 32 bits are semantically used, but moving them to `Int64` keeps bitwise hot paths off boxed `Int`.
+3. Keep fragment shift counts and public `size` as `Int`, since those are already natural `Int` APIs and are not the hot-path hash payload. The intended split is: hash payloads and bitmaps are `Int64`; loop fuel and public counts stay `Int`.
+4. Rework helpers such as `fragment`, `bitpos`, `has_bit`, and `bitmap_index` around `Int64` bitwise operations and `popcount_Int64`.
+5. Move collection-hash adapters for maps and sets to `Int64` accumulators. Their behavior should stay the same at the semantic level: equal collections hash equally, and map or set hash aggregation remains order-independent with respect to traversal or insertion order.
+6. Expand the inline invariant helpers so they check more than cached size. They should validate cached-hash correctness, collision-node consistency, bitmap and array alignment, and canonical hash range.
+
+### Wider Call-Site Sweep
+1. `src/Zafu/Abstract/Instances/Predef.bosatsu` must be updated so all primitive and composite hash builders return `Int64`, including tuple arities, list and string accumulation, and `Dict` hashing.
+2. `src/Zafu/Collection/Vector.bosatsu` has explicit `Int` hash accumulators and should be migrated to `Int64`.
+3. `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu` each define local hash builders with explicit `Int` types and will need direct edits.
+4. Generic `hash_by` users that do not spell out raw hash types should mostly recompile once the core API changes, but they still need coverage in the validation sweep.
+
+## Behavioral Properties and Invariants
+1. Eq/Hash coherence remains mandatory: whenever `eq(x, y)` holds, `hash(x) == hash(y)` must also hold.
+2. Exported hashes stay in the canonical 61-bit non-negative domain `[0, 2^61 - 1)`.
+3. Hash results remain deterministic across supported backends because the implementation uses Bosatsu-defined `Int64` operations rather than host-sized `Int` behavior.
+4. `HashMap` and `HashSet` public semantics do not change: lookup, membership, update, alter, delete, transform, union, intersection, and difference must keep the same logical behavior as before.
+5. Every cached HAMT entry hash equals a fresh recomputation from the stored `Hash[k]` dictionary and key.
+6. Collision nodes contain only entries with the same cached hash, and bitmap nodes keep array sizes aligned with the popcount of their respective bitmaps.
+7. Equal sets and maps must hash equally regardless of insertion order or traversal order. Sequence-like structures such as lists, vectors, tuples, and constructor-tagged sum types must remain order-sensitive or constructor-sensitive where they are today.
+8. Exact numeric hash values are not a post-change invariant. Tests should pin laws and semantics, not old raw hash literals.
+
+## Implementation Plan
+1. Update `src/Zafu/Abstract/Hash.bosatsu` first. Change the core type, change exported helper signatures, and add an internal or test-only reference implementation so Int64 helper behavior can be checked against a simpler oracle.
+2. Sweep `src/Zafu/Abstract/Instances/Predef.bosatsu` next. This is the widest call-site surface because it owns primitive hashes, list and string hashing, tuple hashing, and `Dict` hashing.
+3. Migrate `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu` together. They share the same HAMT representation pattern, so the cached-hash and bitmap conversion should stay structurally parallel.
+4. Update the remaining direct hash producers and consumers in `src/Zafu/Collection/Vector.bosatsu`, `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu`.
+5. Run a repo-wide compile and test sweep with `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` only after the full type migration is in place. Partial rollout is not useful because the repo will be in a mixed, non-compiling state in the middle of the change.
+
+## Test Plan
+
+### Property-Check Coverage
+1. Add randomized property checks for the new Int64 hash helpers in `src/Zafu/Abstract/Hash.bosatsu`. The key property is that canonicalization and mixing satisfy the range invariant and remain coherent with a simple reference implementation over many random inputs.
+2. Keep or expand hash law coverage for predef instances so randomized tests continue to assert Eq/Hash coherence and range invariants for primitives and common composites.
+3. Keep the model-based randomized operation tests in `HashMap` and `HashSet`, but run them against the strengthened HAMT invariants after every step. Those properties are the right place to validate that changing cached-hash types and bitmap types did not change table semantics.
+4. Add permutation-style properties for map and set hash adapters so equal collections built from different insertion orders still hash equally.
+5. Keep randomized collection-hash parity properties such as vector-versus-list hashing where they already exist, because they protect against accidental semantic drift while accumulator types change.
+
+### Narrow Case Coverage
+1. Keep explicit Float64 regression tests for NaN canonicalization and signed zero, since those are small, sharp cases where a single example is more valuable than a broad generator.
+2. Add boundary tests around raw negative inputs, `0`, `-1`, `2^61 - 2`, `2^61 - 1`, and fragment boundaries near shifts `0`, `5`, and `60`. These are the places most likely to expose sign, mask, or reduction mistakes.
+3. Keep direct collision-node insert, remove, and compression tests in `HashMap` and `HashSet`. Randomized model tests are good at finding semantic drift, but specific collapse cases are still best captured as named regressions.
+4. Keep explicit cross-hash bulk-operation tests where left and right collections use different hash dictionaries. Those examples pin the intended fallback behavior more clearly than a generator alone.
+5. Keep small constructor-tagging tests in modules like `Result`, `PartialResult`, and `Text/Parse/Error` so refactors do not accidentally merge distinct hash domains.
+
+## Acceptance Criteria
+1. `docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md` lands with this migration plan and marks the planned milestone for issue #207.
+2. `Hash[a]` and `hash(inst, value)` are Int64-backed, and the repo has a supported constructor path for both already-Int64 hash builders and simple Int projections.
+3. Exported hash helpers enforce the canonical `[0, 2^61 - 1)` range after the migration.
+4. `Predef` hash instances and the tuple, list, string, and dict builders compile and emit `Int64` hashes.
+5. `HashMap` and `HashSet` store cached hashes as `Int64`, use `Int64` bitmaps in their HAMT internals, and keep public behavior unchanged.
+6. Strengthened HAMT invariant helpers validate cached-hash correctness, collision-node consistency, bitmap and popcount alignment, and exact cached size.
+7. Model-based property tests for `HashMap` and `HashSet` continue to pass for default, collision-heavy, and differing-hash-dictionary scenarios.
+8. Case-based tests cover Float64 special cases, boundary normalization cases, and named collision or compression regressions.
+9. Tests stop asserting legacy raw `Int` hash literals unless the value is still intentionally guaranteed after the migration.
+10. `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` pass on the full migration branch.
+
+## Risks and Mitigations
+1. Risk: the new Int64 helper math accidentally changes canonicalization or mixing invariants. Mitigation: add a simple reference oracle in tests and compare the Int64 helpers against it across randomized inputs.
+2. Risk: mixed `Int` and `Int64` conversions in HAMT code introduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and add boundary tests around fragment extraction and node compression.
+3. Risk: a repo-wide type migration misses smaller modules with local `Int`-typed hash helpers. Mitigation: do a deliberate search over `hash_from_fn`, `hash_specialized`, `hash_Hash`, `mix_61`, `finish_61`, and local `def hash_* -> Int` helpers before validation.
+4. Risk: performance gains are diluted if hot paths still bounce between `Int` and `Int64`. Mitigation: make cached hashes, bitmaps, and collection-hash accumulators Int64-first, and treat `Int` as an API boundary type rather than a storage type.
+5. Risk: downstream callers experience source breakage because raw hash types change. Mitigation: land the migration atomically, keep the convenience constructor for Int projections, and update tests and docs to talk about laws rather than concrete old hash numbers.
+
+## Rollout Notes
+1. This design doc merge is the planned milestone for the issue; implementation can continue afterward without reopening design.
+2. The code change should be landed as one compile-green migration PR off `main`. A half-converted repo is not a useful intermediate state.
+3. No feature flag or dual-type rollout is planned. The type system itself is the migration boundary.
+4. If the migration changes concrete hash outputs, that is acceptable so long as the invariants above continue to hold and collection behavior is unchanged.

--- a/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+++ b/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
@@ -67,9 +67,10 @@ A type-only migration would not be enough. If `Hash[a]` changes to `Int64` while
 1. Keep the existing modulus `M = 2^61 - 1` and the existing seed and tag domain-separation strategy. Move those constants to `Int64` so downstream hash builders stay in one representation.
 2. Preserve the canonical exported invariant that every public hash lies in `[0, M)`.
 3. Implement an internal `reduce_61_i64` helper using the Mersenne identity `2^61 ≡ 1 (mod M)`. For bounded non-negative intermediates, fold high bits back into the low 61 bits and subtract `M` when needed.
-4. Implement a dedicated multiply-reduce helper for `mix_61` that stays Int64-first. It should use `Int64` limb decomposition and reduction rather than widening the hot path back to arbitrary-precision `Int`.
-5. Keep `normalize_61` as the compatibility adapter for arbitrary `Int` inputs, but Hash internals and collection internals should prefer Int64-native reduction helpers once data is in the canonical domain.
-6. Validate the Int64 arithmetic against a clearer `Int`-based oracle in tests so the subtle math stays explainable and checkable.
+4. Introduce a dedicated multiply-reduce helper behind `mix_61`, but treat the exact implementation as benchmark-gated. The leading candidate is an Int64 limb-decomposition strategy so the hot path can stay in `Int64`, but the helper boundary should also permit an `Int` multiply plus single reduction fallback if benchmarking shows the simpler path is as fast or faster on supported backends.
+5. If the Int64-first helper uses limb decomposition, implement it with fixed-width chunks small enough to avoid hidden overflow inside each partial product and reduction step.
+6. Keep `normalize_61` as the compatibility adapter for arbitrary `Int` inputs, but Hash internals and collection internals should prefer Int64-native reduction helpers once data is in the canonical domain.
+7. Validate the arithmetic against a clearer `Int`-based oracle in tests, then benchmark the selected `mix_61` helper on representative hash-heavy workloads (`HashMap`, `HashSet`, and collection-hash construction) before locking in the implementation choice.
 
 ### HashMap and HashSet Internals
 1. In `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, change cached `Entry.hash` and `Collision.hash` from `Int` to `Int64`.
@@ -126,7 +127,7 @@ A type-only migration would not be enough. If `Hash[a]` changes to `Int64` while
 ## Acceptance Criteria
 1. `docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md` lands and serves as the planned milestone for issue #207.
 2. `Hash[a]` and `hash(inst, value)` are Int64-backed, and the repo still has a supported constructor path for both Int64-native hash builders and simple Int projections.
-3. The 61-bit helper pipeline is Int64-first in the hot path, including an overflow-safe multiply-reduce strategy for `mix_61`.
+3. The 61-bit helper pipeline has an explicit, benchmarked `mix_61` multiply-reduce strategy. The preferred outcome is an Int64-first hot path, but the design allows a deliberate `Int` multiply plus reduction fallback inside that helper if it proves faster on supported backends.
 4. All exported hash helpers continue to enforce the canonical `[0, 2^61 - 1)` range.
 5. `Predef` hash instances and composite hash builders compile and emit `Int64` hashes.
 6. `HashMap` and `HashSet` store cached hashes and HAMT bitmaps as `Int64`, while preserving existing public behavior.
@@ -136,9 +137,9 @@ A type-only migration would not be enough. If `Hash[a]` changes to `Int64` while
 10. `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` pass on the full migration branch.
 
 ## Risks and Rollout Notes
-1. Risk: the Int64 multiply-reduce helper is subtle and easy to get wrong. Mitigation: isolate it in `Hash`, validate it against a simpler `Int`-based oracle, and add targeted boundary tests in addition to randomized coverage.
+1. Risk: the Int64 multiply-reduce helper is subtle and easy to get wrong. Mitigation: isolate it in `Hash`, validate it against a simpler `Int`-based oracle, add targeted boundary tests in addition to randomized coverage, and keep the helper boundary narrow enough that an `Int` multiply plus reduction fallback remains possible if the limb implementation is not worth the complexity.
 2. Risk: mixed `Int` and `Int64` conversions in HAMT code reintroduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and search specifically for Int-specific hash comparisons and leftover narrowing paths during the sweep.
-3. Risk: the migration achieves the public type change but leaves performance on the table if hot loops still widen back to `Int`. Mitigation: keep cached hashes, bitmaps, fragment helpers, and unordered collection-hash accumulators Int64-first, and treat any remaining `Int` arithmetic as a deliberate boundary or compatibility path.
+3. Risk: the migration achieves the public type change but leaves performance on the table if hot loops still widen back to `Int`, or it pays extra complexity for an Int64 limb path that does not actually win. Mitigation: keep cached hashes, bitmaps, fragment helpers, and unordered collection-hash accumulators Int64-first, but require benchmark evidence before committing to the `mix_61` multiply-reduce implementation and treat any remaining `Int` arithmetic as a deliberate, measured boundary rather than an accidental fallback.
 4. Risk: downstream callers or inline tests depend on the old raw hash type. Mitigation: land the code change atomically, preserve a supported Int-adapter constructor path, and update tests to talk about coherence and invariants rather than `Int`-specific helper APIs.
 5. The design doc merge is the planned milestone for this lane. Implementation can continue afterward from the same child issue without reopening design.
 6. The implementation branch should stay close to `main` while this migration is in flight, because there is no useful long-lived mixed `Int` and `Int64` state for `Hash`.

--- a/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
+++ b/docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md
@@ -11,9 +11,11 @@ touch_paths:
   - src/Zafu/Control/Result.bosatsu
   - src/Zafu/Control/PartialResult.bosatsu
   - src/Zafu/Text/Parse/Error.bosatsu
+  - src/Zafu/Collection/NonEmptyList.bosatsu
+  - src/Zafu/Collection/NonEmptyChain.bosatsu
 depends_on: []
 estimated_size: M
-generated_at: 2026-04-09T22:48:40Z
+generated_at: 2026-04-09T23:05:42Z
 ---
 
 # Design: migrate Hash typeclass to use Int64 not Int
@@ -22,110 +24,115 @@ _Issue: #207 (https://github.com/johnynek/zafu/issues/207)_
 
 ## Summary
 
-Migrate `Hash` to `Int64` while keeping canonical 61-bit hashes, moving `HashMap` and `HashSet` hot-path hashing and bitmap math onto `Int64`, and validating the change with stronger invariant- and property-driven coverage.
+Plan the Int64 migration of `Hash`, move HAMT cached hashes and bitmaps onto `Int64`, and validate the change with stronger invariants plus property-driven tests.
 
 ## Status
-Planned. Merging this doc is the planned milestone for issue #207; implementation can continue on the same child issue afterward.
+Planned. Merging this design doc is the planned milestone for issue #207; implementation may continue afterward on the same child issue.
 
 ## Context
-`Zafu/Abstract/Hash` currently models `Hash[a]` as an `a -> Int` dictionary, and the exported helpers in `Hash`, `Predef`, `HashMap`, and `HashSet` all assume `Int`-typed hash values.
-`HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, node bitmaps, and collection-hash accumulators are still `Int`. That keeps the hottest hash-table paths on unbounded integers even though Bosatsu exposes a dedicated `Int64` API.
-Issue #207 asks for a repo-wide migration of the Hash typeclass to `Int64`, plus an audit of `HashMap` and `HashSet` so their internal hashing work uses `Int64` wherever it is actually on the hot path.
+`Zafu/Abstract/Hash` currently stores `hash_fn: a -> Int`, and the exported helper pipeline in `Hash`, `Predef`, `HashMap`, and `HashSet` assumes `Int`-typed hashes.
+`HashMap` and `HashSet` already use `Int64` for array indexing, but their cached entry hashes, collision hashes, HAMT bitmaps, fragment helpers, and unordered collection-hash accumulators are still `Int`.
+Issue #207 asks for two related changes: move the `Hash` typeclass itself to `Int64`, and audit `HashMap` and `HashSet` so the hot path uses fixed-width integer operations wherever Bosatsu's `Int64` API makes that practical.
+The current design also relies on a canonical non-negative 61-bit hash domain, and HAMT navigation assumes those hashes can be fragmented predictably in 5-bit chunks.
 
 ## Goals
-1. Make `Hash[a]` produce `Int64` rather than `Int`.
-2. Preserve Eq/Hash coherence and deterministic non-cryptographic hashing semantics.
-3. Keep a canonical non-negative 61-bit hash domain so HAMT fragmenting stays stable and sign handling remains simple.
-4. Move `HashMap` and `HashSet` cached hashes, bitmap math, and collection-hash accumulators to `Int64`.
-5. Update in-repo hash producers and consumers with explicit `Int` hash annotations so the repo compiles cleanly after the type change.
-6. Strengthen invariant-driven tests so the migration is validated by behavior, not just by type-checking.
+1. Change `Hash[a]` so the stored hash function and `hash(inst, value)` return `Int64`.
+2. Preserve Eq/Hash coherence and deterministic hashing semantics across supported backends.
+3. Keep the canonical hash domain as `[0, 2^61 - 1)`.
+4. Move `HashMap` and `HashSet` cached hashes, HAMT bitmaps, and unordered collection-hash accumulators to `Int64`.
+5. Update in-repo hash producers and consumers that still assume `Int` hashes.
+6. Strengthen invariant-driven tests so the migration is validated by properties, not only by compilation.
 
 ## Non-goals
-1. Changing public collection sizes or user-facing count APIs from `Int` to `Int64`.
-2. Preserving exact numeric hash outputs across the migration. Behavioral properties matter; specific hash codes do not.
-3. Introducing cryptographic hashing or stronger collision-resistance guarantees.
-4. Reworking unrelated collection algorithms outside of hash-related hot paths.
-5. Carrying a compatibility mode where both `Hash[a] -> Int` and `Hash[a] -> Int64` coexist.
+1. Changing public collection sizes or other user-facing count APIs from `Int` to `Int64`.
+2. Introducing a dual API where both `Hash[a] -> Int` and `Hash[a] -> Int64` remain supported long term.
+3. Redesigning unrelated collection algorithms outside hash-related hot paths.
+4. Promising that every concrete numeric hash output remains part of the public contract, even if the implementation target preserves current 61-bit behavior.
+5. Introducing cryptographic hashing or stronger collision-resistance guarantees.
 
 ## Architecture
 
-### Hash Core
-1. Change `Zafu/Abstract/Hash.bosatsu` so the stored hash function and `hash(inst, value)` both use `Int64`.
-2. Keep the public canonical hash range as `[0, 2^61 - 1)`. This preserves the current invariant that exported hashes are non-negative and leave the sign bit clear.
-3. Keep `hash_specialized` as the fast constructor for already-canonical `Int64` hash functions.
-4. Keep an adapter constructor for simple `Int` projections so instances like `hash_Int` and `hash_Char` do not need repetitive conversion boilerplate. That adapter should normalize in `Int`, then narrow only after the value is known to fit in the canonical 61-bit domain.
-5. Migrate `normalize_61`, `mix_61`, and `finish_61` to Int64-backed helpers. Their hot path should use Bosatsu `Int64` operations only; any wider `Int` arithmetic should be limited to compatibility adapters or reference tests.
-6. Keep domain separation via seeds and tags, but store those constants as `Int64` so downstream hash builders never widen just to mix constructor or collection tags.
-7. `finish_61` should continue accepting collection sizes and tuple arities from public `Int` APIs, but it should reduce those counts into the 61-bit domain before narrowing to `Int64`. That avoids silent truncation while keeping public size APIs unchanged.
+### Hash Core API
+1. Change `src/Zafu/Abstract/Hash.bosatsu` to `struct Hash[a](hash_fn: a -> Int64, eq_inst: Eq[a])` and make `hash(inst, value) -> Int64`.
+2. Keep `hash_specialized` as the fast constructor for already-canonical `Int64` hash functions.
+3. Keep an Int-projection adapter so simple instances such as `hash_Int` and `hash_Char` do not need repetitive conversion boilerplate. The intended shape is to normalize in `Int`, then narrow only after the value is known to fit in the 61-bit canonical domain.
+4. Keep `mix_61` and `finish_61` as the main exported composition helpers, but make their working representation `Int64`.
+5. Continue accepting tuple arity and collection size inputs as `Int` at the public boundary. `finish_61` should reduce or bound-check those counts before converting them into the canonical `Int64` domain so the migration does not rely on silent truncation.
 
-### HashMap and HashSet
-1. In `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, change cached `Entry.hash` and `Collision.hash` fields from `Int` to `Int64`.
-2. Change HAMT bitmaps from `Int` to `Int64` as well. Only the low 32 bits are semantically used, but moving them to `Int64` keeps bitwise hot paths off boxed `Int`.
-3. Keep fragment shift counts and public `size` as `Int`, since those are already natural `Int` APIs and are not the hot-path hash payload. The intended split is: hash payloads and bitmaps are `Int64`; loop fuel and public counts stay `Int`.
-4. Rework helpers such as `fragment`, `bitpos`, `has_bit`, and `bitmap_index` around `Int64` bitwise operations and `popcount_Int64`.
-5. Move collection-hash adapters for maps and sets to `Int64` accumulators. Their behavior should stay the same at the semantic level: equal collections hash equally, and map or set hash aggregation remains order-independent with respect to traversal or insertion order.
-6. Expand the inline invariant helpers so they check more than cached size. They should validate cached-hash correctness, collision-node consistency, bitmap and array alignment, and canonical hash range.
+### 61-bit Int64 Arithmetic
+1. Keep the existing modulus `M = 2^61 - 1` and the existing domain-separation strategy of seeds and tags. Those constants should move to `Int64` so downstream hash builders stay in one numeric representation.
+2. Implement an internal `reduce_61_i64` helper for canonical `Int64` values using the Mersenne identity `2^61 ≡ 1 (mod M)`. For bounded non-negative intermediates, one or two fold-and-subtract passes are enough to return to `[0, M)`.
+3. Implement the hot multiplication step without widening the whole path back to `Int`. The recommended approach is a 31-bit/30-bit limb split for operands below `2^61`, so `mul_mod_61_i64(acc, mix_prime)` can be computed with bounded `Int64` intermediates and then reduced with `reduce_61_i64`.
+4. `mix_61(acc, next)` should therefore stay Int64-first: multiply in the 61-bit domain, add `next` and the fixed additive constant, then reduce back into the canonical range.
+5. `normalize_61` should remain available as the compatibility adapter for arbitrary `Int` inputs, but Hash internals, HAMT internals, and collection accumulators should prefer the Int64-native reduction helpers.
+
+### HashMap and HashSet Internals
+1. In `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, change cached `Entry.hash` and `Collision.hash` from `Int` to `Int64`.
+2. Change `Indexed.data_bitmap` and `Indexed.node_bitmap` from `Int` to `Int64`. Only the low 32 bits are semantically used, but representing them as `Int64` avoids bouncing between `Int` and `Int64` on the same hot path.
+3. Keep public `size`, loop fuel, and shift counts as `Int`. The intended split is: payload hashes and bitmaps are `Int64`; public counts remain `Int`.
+4. Rework helpers such as `fragment`, `bitpos`, `has_bit`, and `bitmap_index` around `Int64` bitwise operations, `popcount_Int64`, and unsigned right shift where fragment extraction would otherwise depend on sign behavior.
+5. Keep map and set hash adapters order-independent. The current `sum_acc` plus `xor_acc` strategy can remain, but the accumulators and XOR path should become `Int64` so equal maps or sets hash equally regardless of insertion order.
+6. Strengthen the test-only invariant helpers so they validate more than cached size: cached-hash correctness, collision-node consistency, bitmap disjointness, bitmap/popcount alignment, canonical range, and exact root size.
 
 ### Wider Call-Site Sweep
-1. `src/Zafu/Abstract/Instances/Predef.bosatsu` must be updated so all primitive and composite hash builders return `Int64`, including tuple arities, list and string accumulation, and `Dict` hashing.
-2. `src/Zafu/Collection/Vector.bosatsu` has explicit `Int` hash accumulators and should be migrated to `Int64`.
-3. `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu` each define local hash builders with explicit `Int` types and will need direct edits.
-4. Generic `hash_by` users that do not spell out raw hash types should mostly recompile once the core API changes, but they still need coverage in the validation sweep.
+1. `src/Zafu/Abstract/Instances/Predef.bosatsu` is the largest direct migration surface. Primitive hashes, string/list hashing, option hashing, tuple hashing, and dict hashing all need Int64-backed helpers and constants.
+2. `src/Zafu/Collection/Vector.bosatsu` has explicit hash accumulators and a parity property against list hashing; it needs a direct migration to Int64-backed composition.
+3. `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu` each define local constructor-tagged hash builders and currently assume `Int`-typed helper outputs.
+4. Inline tests in modules that compare hashes with `eq_Int` or `.eq_Int` must be updated to use `Int64`-appropriate comparisons. The likely touch points include `NonEmptyList` and `NonEmptyChain`, even though their hash implementations are adapter-only.
 
 ## Behavioral Properties and Invariants
-1. Eq/Hash coherence remains mandatory: whenever `eq(x, y)` holds, `hash(x) == hash(y)` must also hold.
-2. Exported hashes stay in the canonical 61-bit non-negative domain `[0, 2^61 - 1)`.
-3. Hash results remain deterministic across supported backends because the implementation uses Bosatsu-defined `Int64` operations rather than host-sized `Int` behavior.
-4. `HashMap` and `HashSet` public semantics do not change: lookup, membership, update, alter, delete, transform, union, intersection, and difference must keep the same logical behavior as before.
-5. Every cached HAMT entry hash equals a fresh recomputation from the stored `Hash[k]` dictionary and key.
-6. Collision nodes contain only entries with the same cached hash, and bitmap nodes keep array sizes aligned with the popcount of their respective bitmaps.
-7. Equal sets and maps must hash equally regardless of insertion order or traversal order. Sequence-like structures such as lists, vectors, tuples, and constructor-tagged sum types must remain order-sensitive or constructor-sensitive where they are today.
-8. Exact numeric hash values are not a post-change invariant. Tests should pin laws and semantics, not old raw hash literals.
+1. Eq/Hash coherence remains mandatory: if `eq(x, y)` holds, then `hash(x) == hash(y)` must also hold.
+2. Every exported hash value remains in `[0, 2^61 - 1)`.
+3. Hash results remain deterministic across supported backends because the implementation is defined in terms of Bosatsu's `Int64` operations and explicit reductions, not host-sized integer behavior.
+4. Sequence-like structures remain order-sensitive. That includes lists, vectors, tuples, and constructor-tagged sum types.
+5. Unordered collection adapters remain order-insensitive. Equal `HashMap` and `HashSet` values must hash equally regardless of insertion order or traversal order.
+6. `HashMap` and `HashSet` public semantics do not change. Lookup, membership, update, alter, remove, transform, union, intersection, and difference must keep the same logical behavior as before.
+7. Every cached HAMT entry hash equals a fresh recomputation from the stored `Hash[k]` dictionary and the stored key.
+8. Collision nodes contain only entries that share the collision hash, and they never persist as empty or single-entry nodes after compression.
+9. Indexed-node invariants remain strict: `data_bitmap & node_bitmap == 0`, `entries.size == popcount(data_bitmap)`, and `children.size == popcount(node_bitmap)`.
+10. Root size remains exact and equals the number of reachable entries.
+11. The migration must not rely on lossy `Int -> Int64` narrowing for sizes, arities, or hash constants. Any such conversion must happen only after the value is known to fit or after explicit reduction into the 61-bit domain.
 
 ## Implementation Plan
-1. Update `src/Zafu/Abstract/Hash.bosatsu` first. Change the core type, change exported helper signatures, and add an internal or test-only reference implementation so Int64 helper behavior can be checked against a simpler oracle.
-2. Sweep `src/Zafu/Abstract/Instances/Predef.bosatsu` next. This is the widest call-site surface because it owns primitive hashes, list and string hashing, tuple hashing, and `Dict` hashing.
-3. Migrate `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu` together. They share the same HAMT representation pattern, so the cached-hash and bitmap conversion should stay structurally parallel.
+1. Migrate `src/Zafu/Abstract/Hash.bosatsu` first. Change the core type signatures, add the Int64 reduction and multiply-reduce helpers, and keep a simple reference implementation in tests so the new arithmetic can be checked against a clearer oracle.
+2. Sweep `src/Zafu/Abstract/Instances/Predef.bosatsu` next. This updates the broadest surface area and unblocks downstream modules that depend on predef hash instances.
+3. Migrate `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu` together. Their HAMT representations and test models are intentionally parallel, so cached-hash and bitmap changes should stay structurally aligned.
 4. Update the remaining direct hash producers and consumers in `src/Zafu/Collection/Vector.bosatsu`, `src/Zafu/Control/Result.bosatsu`, `src/Zafu/Control/PartialResult.bosatsu`, and `src/Zafu/Text/Parse/Error.bosatsu`.
-5. Run a repo-wide compile and test sweep with `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` only after the full type migration is in place. Partial rollout is not useful because the repo will be in a mixed, non-compiling state in the middle of the change.
+5. Finish with the smaller inline-test fallout where modules compare hash values with `Int`-specific helpers.
+6. Validate only once the full repo-wide type migration is in place. A half-converted branch is not a useful intermediate state because `Hash[a]` sits at the center of many modules.
 
 ## Test Plan
 
 ### Property-Check Coverage
-1. Add randomized property checks for the new Int64 hash helpers in `src/Zafu/Abstract/Hash.bosatsu`. The key property is that canonicalization and mixing satisfy the range invariant and remain coherent with a simple reference implementation over many random inputs.
-2. Keep or expand hash law coverage for predef instances so randomized tests continue to assert Eq/Hash coherence and range invariants for primitives and common composites.
-3. Keep the model-based randomized operation tests in `HashMap` and `HashSet`, but run them against the strengthened HAMT invariants after every step. Those properties are the right place to validate that changing cached-hash types and bitmap types did not change table semantics.
-4. Add permutation-style properties for map and set hash adapters so equal collections built from different insertion orders still hash equally.
-5. Keep randomized collection-hash parity properties such as vector-versus-list hashing where they already exist, because they protect against accidental semantic drift while accumulator types change.
+1. Add randomized properties in `src/Zafu/Abstract/Hash.bosatsu` for the new Int64 arithmetic helpers. The key checks are canonical range preservation, reduction idempotence, and agreement with a simple reference implementation for randomly generated canonical inputs.
+2. Keep or expand the hash-law checks in `src/Zafu/Abstract/Instances/Predef.bosatsu` so randomized coverage continues to assert Eq/Hash coherence, canonical range, constructor tagging, and sequence order sensitivity for common composite instances.
+3. Keep the model-based randomized operation tests in `src/Zafu/Collection/HashMap.bosatsu` and `src/Zafu/Collection/HashSet.bosatsu`, but make every step also assert the strengthened HAMT invariants. Those properties are the right place to catch bugs introduced by cached-hash and bitmap type changes.
+4. Add permutation-style properties for map and set hash adapters so collections built from different insertion orders still hash equally.
+5. Keep the `Vector` parity property that `hash_Vector` agrees with list hashing, because it guards a meaningful downstream invariant while the shared hash helpers change underneath it.
 
 ### Narrow Case Coverage
-1. Keep explicit Float64 regression tests for NaN canonicalization and signed zero, since those are small, sharp cases where a single example is more valuable than a broad generator.
-2. Add boundary tests around raw negative inputs, `0`, `-1`, `2^61 - 2`, `2^61 - 1`, and fragment boundaries near shifts `0`, `5`, and `60`. These are the places most likely to expose sign, mask, or reduction mistakes.
-3. Keep direct collision-node insert, remove, and compression tests in `HashMap` and `HashSet`. Randomized model tests are good at finding semantic drift, but specific collapse cases are still best captured as named regressions.
-4. Keep explicit cross-hash bulk-operation tests where left and right collections use different hash dictionaries. Those examples pin the intended fallback behavior more clearly than a generator alone.
-5. Keep small constructor-tagging tests in modules like `Result`, `PartialResult`, and `Text/Parse/Error` so refactors do not accidentally merge distinct hash domains.
+1. Keep explicit `Float64` regressions for NaN canonicalization and signed zero. Those are small, sharp semantic cases where a named example is more valuable than a broad generator.
+2. Add boundary tests for normalization and fragment extraction around `-1`, `0`, `2^61 - 2`, `2^61 - 1`, and the fragment-shift boundaries `0`, `5`, and `60`.
+3. Keep direct collision-node insert/remove/compression tests in `HashMap` and `HashSet`. Randomized model tests are good at finding semantic drift, but node-collapse edge cases are still best pinned as named regressions.
+4. Keep explicit cross-dictionary bulk-operation tests where left and right collections use different hash dictionaries. Those examples pin the intended fallback behavior more clearly than a generator alone.
+5. Keep constructor-tagging checks in `Result`, `PartialResult`, and `Text/Parse/Error` so refactors do not accidentally collapse distinct variants into the same hash domain.
 
 ## Acceptance Criteria
-1. `docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md` lands with this migration plan and marks the planned milestone for issue #207.
-2. `Hash[a]` and `hash(inst, value)` are Int64-backed, and the repo has a supported constructor path for both already-Int64 hash builders and simple Int projections.
-3. Exported hash helpers enforce the canonical `[0, 2^61 - 1)` range after the migration.
-4. `Predef` hash instances and the tuple, list, string, and dict builders compile and emit `Int64` hashes.
-5. `HashMap` and `HashSet` store cached hashes as `Int64`, use `Int64` bitmaps in their HAMT internals, and keep public behavior unchanged.
-6. Strengthened HAMT invariant helpers validate cached-hash correctness, collision-node consistency, bitmap and popcount alignment, and exact cached size.
-7. Model-based property tests for `HashMap` and `HashSet` continue to pass for default, collision-heavy, and differing-hash-dictionary scenarios.
-8. Case-based tests cover Float64 special cases, boundary normalization cases, and named collision or compression regressions.
-9. Tests stop asserting legacy raw `Int` hash literals unless the value is still intentionally guaranteed after the migration.
+1. `docs/design/207-migrate-hash-typeclass-to-use-int64-not-int.md` lands and serves as the planned milestone for issue #207.
+2. `Hash[a]` and `hash(inst, value)` are Int64-backed, and the repo still has a supported constructor path for both Int64-native hash builders and simple Int projections.
+3. The 61-bit helper pipeline is Int64-first in the hot path, including an overflow-safe multiply-reduce strategy for `mix_61`.
+4. All exported hash helpers continue to enforce the canonical `[0, 2^61 - 1)` range.
+5. `Predef` hash instances and composite hash builders compile and emit `Int64` hashes.
+6. `HashMap` and `HashSet` store cached hashes and HAMT bitmaps as `Int64`, while preserving existing public behavior.
+7. Strengthened HAMT invariants validate cached-hash correctness, collision-node consistency, bitmap alignment, bitmap disjointness, canonical range, and exact cached size.
+8. Property tests continue to pass for default, collision-heavy, and differing-hash-dictionary scenarios in `HashMap` and `HashSet`, and the `Vector` hash parity property still holds.
+9. Case-based tests cover `Float64` special cases, 61-bit boundary normalization, constructor tagging, and named collision/compression regressions.
 10. `./bosatsu lib check`, `./bosatsu lib test`, and `scripts/test.sh` pass on the full migration branch.
 
-## Risks and Mitigations
-1. Risk: the new Int64 helper math accidentally changes canonicalization or mixing invariants. Mitigation: add a simple reference oracle in tests and compare the Int64 helpers against it across randomized inputs.
-2. Risk: mixed `Int` and `Int64` conversions in HAMT code introduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and add boundary tests around fragment extraction and node compression.
-3. Risk: a repo-wide type migration misses smaller modules with local `Int`-typed hash helpers. Mitigation: do a deliberate search over `hash_from_fn`, `hash_specialized`, `hash_Hash`, `mix_61`, `finish_61`, and local `def hash_* -> Int` helpers before validation.
-4. Risk: performance gains are diluted if hot paths still bounce between `Int` and `Int64`. Mitigation: make cached hashes, bitmaps, and collection-hash accumulators Int64-first, and treat `Int` as an API boundary type rather than a storage type.
-5. Risk: downstream callers experience source breakage because raw hash types change. Mitigation: land the migration atomically, keep the convenience constructor for Int projections, and update tests and docs to talk about laws rather than concrete old hash numbers.
-
-## Rollout Notes
-1. This design doc merge is the planned milestone for the issue; implementation can continue afterward without reopening design.
-2. The code change should be landed as one compile-green migration PR off `main`. A half-converted repo is not a useful intermediate state.
-3. No feature flag or dual-type rollout is planned. The type system itself is the migration boundary.
-4. If the migration changes concrete hash outputs, that is acceptable so long as the invariants above continue to hold and collection behavior is unchanged.
+## Risks and Rollout Notes
+1. Risk: the Int64 multiply-reduce helper is subtle and easy to get wrong. Mitigation: isolate it in `Hash`, validate it against a simpler reference implementation, and add targeted boundary tests in addition to random coverage.
+2. Risk: mixed `Int` and `Int64` conversions in HAMT code reintroduce fragment or bitmap bugs. Mitigation: keep the type split explicit, strengthen invariants, and search specifically for `eq_Int`, `.eq_Int`, `hash_from_fn`, `hash_specialized`, `mix_61`, and `finish_61` call sites during the sweep.
+3. Risk: the migration achieves the public type change but leaves performance on the table if hot loops still widen back to `Int`. Mitigation: keep cached hashes, bitmaps, fragment helpers, and unordered collection-hash accumulators Int64-first, and treat any remaining `Int` arithmetic as a deliberate boundary or compatibility path.
+4. Risk: downstream callers or inline tests depend on the old raw hash type. Mitigation: land the code change atomically, preserve an Int-projection constructor path, and update tests to talk about coherence and invariants rather than `Int`-specific helper APIs.
+5. The design doc merge is the planned milestone for this lane. Implementation can continue afterward from the same child issue without reopening design.
+6. The code rollout should stay compile-green from `main`. If the implementation is split, each step still needs to leave the repo building; there is no useful long-lived mixed `Int`/`Int64` state for `Hash`.


### PR DESCRIPTION
Design doc.

Refs #207